### PR TITLE
Fix Windows installer tests, add CI, and standardize Omasend branding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Formatting and Clippy
+    runs-on: macos-26
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ci-quality
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+  test:
+    name: Tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-26, ubuntu-22.04, windows-2022]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ci-tests
+      - name: Unix installer tests
+        if: runner.os != 'Windows'
+        run: python scripts/test-install.py
+      - name: Windows installer tests
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/test-install.ps1
+      - name: Unit and integration tests
+        run: cargo test --locked --no-default-features
+      - name: GPUI interaction tests
+        if: runner.os == 'macOS'
+        run: cargo test --locked --features ui-tests --bin omasend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,4 +175,4 @@ jobs:
           prerelease=()
           if [[ "$RELEASE_TAG" == *-* ]]; then prerelease+=(--prerelease); fi
           gh release create "$RELEASE_TAG" --verify-tag --generate-notes \
-            --title "OmaSend $RELEASE_TAG" "${prerelease[@]}" dist/*
+            --title "Omasend $RELEASE_TAG" "${prerelease[@]}" dist/*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OmaSend
+# Omasend
 
 A native GPUI + gpui-omarchy LocalSend client for Omarchy and Wayland.
 
@@ -82,7 +82,7 @@ Ensure `~/.local/bin` is on PATH. On Omarchy, use
 - Logs… in the menu opens the latest 500 session log events, with copy and
   clear actions. Ordinary background discovery timeouts stay in the logs.
 - Exit is in the menu. Omarchy's compositor owns `super+w` window closing;
-  OmaSend does not override it or bind `ctrl+q`.
+  Omasend does not override it or bind `ctrl+q`.
 - macOS also accepts `cmd+v`, `cmd+o`, and `cmd+q`. `cmd+w` closes the
   window while keeping the session available from the Dock.
 
@@ -123,7 +123,7 @@ is unchanged. WebRTC and web sharing are disabled.
 existing `keycap` component and keyboard traversal respecting modal focus traps.
 See its `UPSTREAM.txt`.
 
-The original OmaSend emblem is inspired by LocalSend's local-discovery shape
+The original Omasend emblem is inspired by LocalSend's local-discovery shape
 and Omarchy's pixel geometry; it is not either project's official mark. Linux
 uses the square PNG; macOS combines Icon Composer assets for modern systems
 with a rounded, transparent-margin ICNS for older releases.
@@ -132,7 +132,7 @@ Both render a transparent vector emblem in the current theme's accent color.
 GPUI's reduced-motion setting renders a static logo.
 
 The menu includes About… with the current version and Check for update.
-OmaSend checks GitHub's latest stable release at startup and every six hours.
+Omasend checks GitHub's latest stable release at startup and every six hours.
 Click Install in the status bar to download and install that version with
 [self_update](https://github.com/jaemk/self_update). The updater requires the
 release's SHA256SUMS checksum before replacing files. macOS updates the entire

--- a/assets/OmaSend.icon/icon.json
+++ b/assets/OmaSend.icon/icon.json
@@ -6,7 +6,7 @@
         {
           "glass": false,
           "image-name": "omasend.png",
-          "name": "OmaSend pixel mark"
+          "name": "Omasend pixel mark"
         }
       ],
       "shadow": { "kind": "neutral", "opacity": 0 },

--- a/assets/icon-provenance.txt
+++ b/assets/icon-provenance.txt
@@ -1,4 +1,4 @@
-OmaSend application icon
+Omasend application icon
 
 Original generated artwork for this project. The solid central packet and
 segmented perimeter refer to local discovery and exchange, informed by the

--- a/docs/RFC.md
+++ b/docs/RFC.md
@@ -1,6 +1,6 @@
 下面这版可以直接保存成 `RFC-OmaSend.md`，也适合直接交给 AI Coding Agent 作为开发指引。
 
-# OmaSend — Omarchy Native LocalSend Client
+# Omasend — Omarchy Native LocalSend Client
 
 > Status: Draft
 > Target: v0.1
@@ -10,13 +10,13 @@
 
 ## 1. 项目目标
 
-OmaSend 是一个专门面向 Omarchy 的 LocalSend 兼容客户端。
+Omasend 是一个专门面向 Omarchy 的 LocalSend 兼容客户端。
 
 第一阶段的目标非常克制：
 
 > **用 GPUI 实现一个真正符合 Omarchy 视觉、交互和键盘操作习惯的 LocalSend 客户端，作为 Omarchy 当前 LocalSend Flutter GUI 的原生替代。**
 
-OmaSend **不是重新设计 LocalSend 协议**，也暂时不是 Omarchy 的系统级 AirDrop。
+Omasend **不是重新设计 LocalSend 协议**，也暂时不是 Omarchy 的系统级 AirDrop。
 
 核心价值是：
 
@@ -28,7 +28,7 @@ OmaSend **不是重新设计 LocalSend 协议**，也暂时不是 Omarchy 的系
 * 与 Omarchy Screenshot / Screen Recording / Clipboard 工作流自然结合
 * 与现有 LocalSend Android / iOS / macOS / Windows / Linux 客户端完全互通
 
-未来如果 OmaSend 被社区接受，再逐步向 Omarchy 的系统级文件传输能力演进。
+未来如果 Omasend 被社区接受，再逐步向 Omarchy 的系统级文件传输能力演进。
 
 ---
 
@@ -44,7 +44,7 @@ v0.1 不做：
 * 自研协议
 * 公网传输
 * WebRTC
-* OmaSend 手机客户端
+* Omasend 手机客户端
 * 系统级 AirDrop replacement
 * 复杂账号体系
 * 云端服务
@@ -56,7 +56,7 @@ omarchy-launch-or-focus omasend
               │
               ▼
         ┌──────────────┐
-        │   OmaSend    │
+        │   Omasend    │
         │    GPUI      │
         └──────┬───────┘
                │
@@ -94,7 +94,7 @@ LocalSend 当前公开协议已经发展到 **Protocol v2.2**，默认使用 UDP
 
 LocalSend 在 2026 年已经完成核心网络和文件 I/O 的 Rust 化，v1.18.0 的 CLI 与 Flutter App 使用相同的 Rust library。([GitHub][2])
 
-因此 OmaSend 应首先研究并复用：
+因此 Omasend 应首先研究并复用：
 
 ```text
 localsend/localsend
@@ -117,7 +117,7 @@ packages/core/src/http/dto_v2.rs
 ```text
 1. 直接依赖 / vendoring 官方 LocalSend Rust core
         ↓
-2. 如果 API 不适合外部使用，做很薄的 OmaSend adapter
+2. 如果 API 不适合外部使用，做很薄的 Omasend adapter
         ↓
 3. 只有确实无法复用时，才自行实现协议部分
 ```
@@ -172,13 +172,13 @@ Clipboard Video
 Clipboard File
 ```
 
-其中 **Clipboard 是 OmaSend 的重点体验之一。**
+其中 **Clipboard 是 Omasend 的重点体验之一。**
 
 ---
 
 # 6. Clipboard First
 
-OmaSend 必须把：
+Omasend 必须把：
 
 > **复制 → 粘贴 → 发送**
 
@@ -199,7 +199,7 @@ OmaSend 必须把：
 ```text
 Copy
 ↓
-打开 OmaSend
+打开 Omasend
 ↓
 Ctrl+V
 ↓
@@ -211,7 +211,7 @@ Send
 甚至可以进一步做到：
 
 ```text
-打开 OmaSend
+打开 Omasend
 ↓
 Ctrl+V
 ↓
@@ -269,7 +269,7 @@ text/uri-list
 file:///home/jason/Pictures/demo.png
 ```
 
-OmaSend 应解析成本地文件：
+Omasend 应解析成本地文件：
 
 ```rust
 SendItem::File(PathBuf)
@@ -292,7 +292,7 @@ UI 显示：
 
 # 9. Clipboard Image
 
-这是 OmaSend 的重要场景。
+这是 Omasend 的重要场景。
 
 Omarchy 官方截图工作流本身就会：
 
@@ -301,7 +301,7 @@ Omarchy 官方截图工作流本身就会：
 
 官方文档明确描述截图结果同时进入 `~/Pictures` 和 clipboard。([GitHub][5])
 
-所以典型 OmaSend 工作流是：
+所以典型 Omasend 工作流是：
 
 ```text
 Print Screen
@@ -310,7 +310,7 @@ Omarchy Screenshot
      ↓
 Clipboard: image/png
      ↓
-打开 OmaSend
+打开 Omasend
      ↓
 Ctrl+V
      ↓
@@ -329,7 +329,7 @@ image/png
 
 而不是文件 URI：
 
-OmaSend 创建临时文件：
+Omasend 创建临时文件：
 
 ```text
 $XDG_RUNTIME_DIR/omasend/
@@ -352,7 +352,7 @@ Screen Recording 应采用与 File 相同的模型。
 
 Omarchy 官方录屏/转码工作流本身已经大量围绕 `~/Videos`、文件以及 clipboard file URI 工作。例如 Transcode 完成后会把生成文件的 file URI 写入 clipboard，供支持 file drop 的应用直接粘贴。([GitHub][5])
 
-因此 OmaSend 不应该特殊设计一套：
+因此 Omasend 不应该特殊设计一套：
 
 ```text
 ScreenRecording
@@ -441,7 +441,7 @@ Ctrl+V
 例如：
 
 ```text
-OmaSend
+Omasend
 ────────────────────────────────────
 
 Nearby
@@ -520,7 +520,7 @@ File Manager
      │
      │ drag
      ▼
-  OmaSend
+  Omasend
 ```
 
 与 Clipboard 共用：
@@ -617,10 +617,10 @@ IMG_3021.HEIC
 不要：
 
 ```text
-~/Downloads/OmaSend
+~/Downloads/Omasend
 ```
 
-不要创建 OmaSend 专属目录。
+不要创建 Omasend 专属目录。
 
 目标是和 AirDrop 类似：
 
@@ -700,7 +700,7 @@ update state
 
 ```text
 ┌─────────────────────────────────────┐
-│               OmaSend               │
+│               Omasend               │
 │                                     │
 │  ┌───────────────────────────────┐  │
 │  │           GPUI UI             │  │
@@ -710,7 +710,7 @@ update state
 │  └───────────────┬───────────────┘  │
 │                  │                  │
 │  ┌───────────────▼───────────────┐  │
-│  │        OmaSend App State      │  │
+│  │        Omasend App State      │  │
 │  └───────────────┬───────────────┘  │
 │                  │                  │
 │  ┌───────────────▼───────────────┐  │
@@ -772,7 +772,7 @@ omasend/
 
 # 22. GPUI / UI
 
-OmaSend 必须使用：
+Omasend 必须使用：
 
 ```text
 GPUI
@@ -788,13 +788,13 @@ GPUI Omarchy
 
 > **GPUI Omarchy 的真实生产应用 / dogfooding 项目。**
 
-因此 OmaSend 中遇到的通用 UI 能力缺口：
+因此 Omasend 中遇到的通用 UI 能力缺口：
 
 ```text
 GPUI Omarchy
 ```
 
-应该优先补回主题库，而不是在 OmaSend 中 hack。
+应该优先补回主题库，而不是在 Omasend 中 hack。
 
 ---
 
@@ -895,7 +895,7 @@ LocalSend 当前默认通过 HTTPS 传输，并动态生成 TLS certificate。([
 
 因此原则是：
 
-> **OmaSend 应继承官方 Rust core 的 TLS / fingerprint / verification 行为，而不是自己做一套“简化版 HTTP”。**
+> **Omasend 应继承官方 Rust core 的 TLS / fingerprint / verification 行为，而不是自己做一套“简化版 HTTP”。**
 
 这也是优先复用官方 core 的重要原因。
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -1,4 +1,4 @@
-# OmaSend v0.1 implementation and acceptance
+# Omasend v0.1 implementation and acceptance
 
 Spec: [RFC-OmaSend.md](../RFC-OmaSend.md). The source RFC ends before listing its development order; this document supplies the sequence without reducing its scope.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,7 +30,7 @@ and icon under the prefix's `share` directory. A custom prefix also needs its
 distribution's graphics/Wayland runtime libraries and `wl-clipboard` for paste.
 The installer does not modify package-manager or shell configuration.
 
-Run the installer again to upgrade. Close OmaSend before upgrading.
+Run the installer again to upgrade. Close Omasend before upgrading.
 
 ## Windows
 
@@ -56,7 +56,7 @@ users can run `omasend` or install the bundled desktop entry and icon.
 
 To uninstall, close the app and remove its installation files. On macOS,
 remove `~/Applications/OmaSend.app`. On Windows, remove the install directory
-and the OmaSend Start menu shortcut. On Linux, remove `bin/omasend`,
+and the Omasend Start menu shortcut. On Linux, remove `bin/omasend`,
 `share/applications/omasend.desktop`, and
 `share/icons/hicolor/1024x1024/apps/omasend.png` under the chosen prefix.
 Received files in Downloads are retained.

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-# Install the published OmaSend app for the current Windows user.
+# Install the published Omasend app for the current Windows user.
 [CmdletBinding()]
 param(
     [string]$Version = 'latest',
@@ -26,7 +26,7 @@ $base = "$repository/releases/download/v$Version"
 $work = Join-Path ([IO.Path]::GetTempPath()) ('omasend-install-' + [Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $work | Out-Null
 try {
-    Write-Host "Downloading OmaSend $Version for $target…"
+    Write-Host "Downloading Omasend $Version for $target…"
     $archive = Join-Path $work $asset
     Invoke-WebRequest -UseBasicParsing -Uri "$base/$asset" -OutFile $archive
     $checksums = Join-Path $work 'SHA256SUMS'
@@ -42,14 +42,14 @@ try {
     New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
     # Windows refuses replacement while the app is running; report the failure.
     Copy-Item -Path (Join-Path $unpacked '*') -Destination $InstallDir -Recurse -Force
-    $startMenu = Join-Path ([Environment]::GetFolderPath('Programs')) 'OmaSend.lnk'
+    $startMenu = Join-Path ([Environment]::GetFolderPath('Programs')) 'Omasend.lnk'
     $shell = New-Object -ComObject WScript.Shell
     $shortcut = $shell.CreateShortcut($startMenu)
     $shortcut.TargetPath = Join-Path $InstallDir 'omasend.exe'
     $shortcut.WorkingDirectory = $InstallDir
     $shortcut.IconLocation = "$InstallDir\omasend.exe,0"
     $shortcut.Save()
-    Write-Host "Installed $InstallDir. Launch OmaSend from the Start menu."
+    Write-Host "Installed $InstallDir. Launch Omasend from the Start menu."
 } finally {
     Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Install the published OmaSend app for the current user. No sudo required.
+# Install the published Omasend app for the current user. No sudo required.
 set -eu
 
 version="${OMASEND_VERSION:-latest}"
@@ -18,7 +18,7 @@ while [ "$#" -gt 0 ]; do
     *) usage >&2; exit 2 ;;
   esac
 done
-die() { printf 'OmaSend: %s\n' "$*" >&2; exit 1; }
+die() { printf 'Omasend: %s\n' "$*" >&2; exit 1; }
 for tool in curl tar awk; do command -v "$tool" >/dev/null || die "Required command missing: $tool"; done
 case "$(uname -s)" in
   Darwin) platform=macos; suffix=apple-darwin; destination="${destination:-$HOME/Applications}" ;;
@@ -45,7 +45,7 @@ asset="omasend-$version-$arch-$suffix.tar.gz"
 base="$repo/releases/download/v$version"
 work="$(mktemp -d "${TMPDIR:-/tmp}/omasend-install.XXXXXXXX")"
 trap 'rm -rf "$work"' 0
-printf 'Downloading OmaSend %s for %s %s…\n' "$version" "$platform" "$arch"
+printf 'Downloading Omasend %s for %s %s…\n' "$version" "$platform" "$arch"
 download "$base/$asset" --output "$work/$asset"
 download "$base/SHA256SUMS" --output "$work/SHA256SUMS"
 expected="$(awk -v name="$asset" '$2 == name || $2 == "*" name { print $1 }' "$work/SHA256SUMS")"

--- a/packaging/build-release.py
+++ b/packaging/build-release.py
@@ -51,8 +51,8 @@ def package(root, binary, output, version, target):
             with (contents / "Info.plist").open("wb") as stream:
                 plistlib.dump({
                     "CFBundleIdentifier": "org.omasend.OmaSend",
-                    "CFBundleName": "OmaSend",
-                    "CFBundleDisplayName": "OmaSend",
+                    "CFBundleName": "Omasend",
+                    "CFBundleDisplayName": "Omasend",
                     "CFBundleExecutable": "omasend",
                     "CFBundleIconFile": "omasend.icns",
                     "CFBundleIconName": "OmaSend",
@@ -62,7 +62,7 @@ def package(root, binary, output, version, target):
                     "LSMinimumSystemVersion": "13.0",
                     "LSApplicationCategoryType": "public.app-category.utilities",
                     "NSHighResolutionCapable": True,
-                    "NSLocalNetworkUsageDescription": "OmaSend discovers nearby devices and transfers files on your local network.",
+                    "NSLocalNetworkUsageDescription": "Omasend discovers nearby devices and transfers files on your local network.",
                     "CFBundleLocalizations": ["en", "zh_CN"],
                 }, stream)
             # Ad-hoc signing preserves executable integrity on Apple Silicon.

--- a/scripts/test-install.ps1
+++ b/scripts/test-install.ps1
@@ -5,14 +5,18 @@ $installer = Join-Path (Split-Path $PSScriptRoot -Parent) 'install.ps1'
 $testRoot = Join-Path ([IO.Path]::GetTempPath()) ('omasend-installer-test-' + [Guid]::NewGuid().ToString('N'))
 $oldArchitecture = $env:PROCESSOR_ARCHITECTURE
 $oldWowArchitecture = $env:PROCESSOR_ARCHITEW6432
-$script:shortcutSaved = $null
-$script:latestCalls = 0
-$script:downloadCalls = 0
+# Mocks run inside the installer's child script scope. Mutate one shared
+# object instead of rebinding $script: variables in that child scope.
+$installerTestState = [PSCustomObject]@{
+    ShortcutSaved = $null
+    LatestCalls = 0
+    DownloadCalls = 0
+}
 
 function Invoke-RestMethod {
     param([string]$Uri)
     if ($Uri -ne 'https://api.github.com/repos/huacnlee/omasend/releases/latest') { throw "Unexpected API request: $Uri" }
-    $script:latestCalls++
+    $installerTestState.LatestCalls++
     return @{ tag_name = 'v0.1.0' }
 }
 
@@ -20,18 +24,29 @@ function Invoke-WebRequest {
     param([switch]$UseBasicParsing, [string]$Uri, [string]$OutFile)
     $prefix = 'https://github.com/huacnlee/omasend/releases/download/v0.1.0/'
     if (-not $Uri.StartsWith($prefix)) { throw "Unexpected download: $Uri" }
-    $script:downloadCalls++
+    $installerTestState.DownloadCalls++
     Copy-Item -LiteralPath (Join-Path $testRoot $Uri.Substring($prefix.Length)) -Destination $OutFile
 }
 
 function New-Object {
-    param([string]$ComObject)
+    [CmdletBinding(DefaultParameterSetName = 'Net')]
+    param(
+        [Parameter(Mandatory, Position = 0, ParameterSetName = 'Net')][string]$TypeName,
+        [Parameter(Position = 1, ParameterSetName = 'Net')][object[]]$ArgumentList,
+        [Parameter(Mandatory, ParameterSetName = 'Com')][string]$ComObject,
+        [System.Collections.IDictionary]$Property,
+        [switch]$Strict
+    )
+    # Archive module autoloading can also construct ordinary .NET objects.
+    if ($PSCmdlet.ParameterSetName -eq 'Net') {
+        return Microsoft.PowerShell.Utility\New-Object @PSBoundParameters
+    }
     if ($ComObject -ne 'WScript.Shell') { throw "Unexpected COM object: $ComObject" }
     $shell = [PSCustomObject]@{}
     $shell | Add-Member -MemberType ScriptMethod -Name CreateShortcut -Value {
         param($Path)
         $shortcut = [PSCustomObject]@{ Path = $Path; TargetPath = ''; WorkingDirectory = ''; IconLocation = '' }
-        $shortcut | Add-Member -MemberType ScriptMethod -Name Save -Value { $script:shortcutSaved = $this }
+        $shortcut | Add-Member -MemberType ScriptMethod -Name Save -Value { $installerTestState.ShortcutSaved = $this }
         return $shortcut
     }
     return $shell
@@ -67,16 +82,17 @@ try {
     $destination = Join-Path $testRoot 'install with spaces'
 
     & $installer -InstallDir $destination
-    Assert-True ($script:latestCalls -eq 1) 'latest release lookup'
+    Assert-True ($installerTestState.LatestCalls -eq 1) 'latest release lookup'
+    Assert-True ($installerTestState.DownloadCalls -eq 2) 'archive and checksum downloads'
     Assert-True (Test-Path -LiteralPath (Join-Path $destination 'omasend.exe')) 'executable installed'
     Assert-True (Test-Path -LiteralPath (Join-Path $destination 'LICENSE')) 'supporting files installed'
-    Assert-True ($script:shortcutSaved.TargetPath -eq (Join-Path $destination 'omasend.exe')) 'shortcut targets installed executable'
-    Assert-True ($script:shortcutSaved.WorkingDirectory -eq $destination) 'shortcut working directory'
+    Assert-True ($installerTestState.ShortcutSaved.TargetPath -eq (Join-Path $destination 'omasend.exe')) 'shortcut targets installed executable'
+    Assert-True ($installerTestState.ShortcutSaved.WorkingDirectory -eq $destination) 'shortcut working directory'
     Write-Host 'PASS latest release installation and shortcut'
 
     Set-Content -LiteralPath (Join-Path $destination 'omasend.exe') -Value 'old executable'
     & $installer -Version v0.1.0 -InstallDir $destination
-    Assert-True ($script:latestCalls -eq 1) 'explicit version avoids latest lookup'
+    Assert-True ($installerTestState.LatestCalls -eq 1) 'explicit version avoids latest lookup'
     Assert-True ((Get-Content (Join-Path $destination 'omasend.exe')) -eq 'fixture executable v1') 'upgrade replaces executable'
     Write-Host 'PASS explicit version upgrade'
 
@@ -91,11 +107,11 @@ try {
     Assert-Fails { & $installer -Version 0.1.0 -InstallDir $destination } 'Missing or ambiguous checksum'
     Write-Host 'PASS duplicate checksum rejection'
 
-    $downloadsBefore = $script:downloadCalls
+    $downloadsBefore = $installerTestState.DownloadCalls
     Assert-Fails { & $installer -Version '../bad' -InstallDir $destination } 'Version must be'
     $env:PROCESSOR_ARCHITECTURE = 'ARM64'
     Assert-Fails { & $installer -Version 0.1.0 -InstallDir $destination } 'x86_64 only'
-    Assert-True ($script:downloadCalls -eq $downloadsBefore) 'invalid input avoids downloads'
+    Assert-True ($installerTestState.DownloadCalls -eq $downloadsBefore) 'invalid input avoids downloads'
     Write-Host 'PASS invalid version and unsupported architecture'
 
     $env:PROCESSOR_ARCHITECTURE = 'AMD64'

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -6,7 +6,7 @@ use tokio::{io::AsyncReadExt, process::Command};
 
 fn runtime_directory() -> Result<PathBuf> {
     let root = std::env::var_os("XDG_RUNTIME_DIR")
-        .context("XDG_RUNTIME_DIR is not set; start OmaSend in your Wayland session")?;
+        .context("XDG_RUNTIME_DIR is not set; start Omasend in your Wayland session")?;
     let directory = PathBuf::from(root).join("omasend");
     let mut builder = std::fs::DirBuilder::new();
     #[cfg(unix)]

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -75,7 +75,7 @@ pub fn init() {
         .with_writer(LogWriter)
         .with_ansi(false)
         .init();
-    tracing::info!("OmaSend session started");
+    tracing::info!("Omasend session started");
 }
 
 #[cfg(test)]

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -181,7 +181,7 @@ const CATALOG: &[(&str, &str)] = &[
         "正在查找设备… 请在同一 Wi-Fi 下打开 LocalSend。",
     ),
     ("Save to your Downloads folder", "保存到下载文件夹"),
-    ("Add to OmaSend", "添加到 OmaSend"),
+    ("Add to Omasend", "添加到 Omasend"),
     ("Clipboard is empty", "剪贴板为空"),
     (
         "Copy the image as PNG or JPEG",
@@ -198,8 +198,8 @@ const CATALOG: &[(&str, &str)] = &[
     ("{count} file", "{count} 个文件"),
     ("{count} files", "{count} 个文件"),
     (
-        "XDG_RUNTIME_DIR is not set; start OmaSend in your Wayland session",
-        "未设置 XDG_RUNTIME_DIR；请在 Wayland 会话中启动 OmaSend",
+        "XDG_RUNTIME_DIR is not set; start Omasend in your Wayland session",
+        "未设置 XDG_RUNTIME_DIR；请在 Wayland 会话中启动 Omasend",
     ),
     (
         "Clipboard temporary directory is not a directory",

--- a/src/localsend/adapter.rs
+++ b/src/localsend/adapter.rs
@@ -127,7 +127,7 @@ impl Node {
         let info = ClientInfo {
             alias: config.alias.clone(),
             version: PROTOCOL_VERSION_V2.into(),
-            device_model: Some("OmaSend".into()),
+            device_model: Some("Omasend".into()),
             device_type: Some(DeviceType::Desktop),
             token: identity.fingerprint.clone(),
         };
@@ -152,7 +152,7 @@ impl Node {
         let device = Device {
             fingerprint: identity.fingerprint.clone(),
             alias: config.alias,
-            model: "OmaSend".into(),
+            model: "Omasend".into(),
             host: "127.0.0.1".into(),
             port: server.port(),
         };
@@ -582,7 +582,7 @@ impl Actor {
             ServerEventV2::ListenerFailed { error } => emit(
                 &self.events,
                 TransferEvent::NetworkError(format!(
-                    "Receiving stopped: {error}. Reopen OmaSend to reconnect."
+                    "Receiving stopped: {error}. Reopen Omasend to reconnect."
                 )),
             ),
         }
@@ -875,7 +875,7 @@ fn machine_name() -> String {
         .trim()
         .to_owned();
     if hostname.is_empty() {
-        "OmaSend".into()
+        "Omasend".into()
     } else {
         hostname
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,20 +64,20 @@ fn main() -> anyhow::Result<()> {
         let handle = handle.clone();
         application.on_reopen(move |cx| {
             if let Err(error) = open_or_activate_window(cx, handle.clone()) {
-                tracing::error!("Could not reopen OmaSend: {error:#}");
+                tracing::error!("Could not reopen Omasend: {error:#}");
             }
         });
     }
     application.run(move |cx| {
         gpui_omarchy::init(cx);
-        cx.set_app_identity("omasend", "OmaSend");
+        cx.set_app_identity("omasend", "Omasend");
         views::init(cx);
         views::theme::load(cx);
         cx.set_global(DesktopSession { home: None });
         cx.on_action(|_: &views::Quit, cx| cx.quit());
         #[cfg(target_os = "macos")]
         cx.set_menus(vec![
-            gpui_omarchy::gpui::Menu::new("OmaSend")
+            gpui_omarchy::gpui::Menu::new("Omasend")
                 .items([gpui_omarchy::gpui::MenuItem::action("Exit", views::Quit)]),
         ]);
         #[cfg(not(target_os = "macos"))]
@@ -88,7 +88,7 @@ fn main() -> anyhow::Result<()> {
         })
         .detach();
         if let Err(error) = open_or_activate_window(cx, handle) {
-            eprintln!("Could not open OmaSend: {error:#}");
+            eprintln!("Could not open Omasend: {error:#}");
             cx.quit();
         }
     });

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -40,7 +40,7 @@ fn client_builder() -> localsend::reqwest::ClientBuilder {
 
 pub async fn check() -> Result<UpdateState> {
     let client = client_builder()
-        .user_agent(concat!("OmaSend/", env!("CARGO_PKG_VERSION")))
+        .user_agent(concat!("Omasend/", env!("CARGO_PKG_VERSION")))
         .timeout(std::time::Duration::from_secs(15))
         .build()?;
     check_at(&client, LATEST_API, env!("CARGO_PKG_VERSION")).await

--- a/src/updates/install.rs
+++ b/src/updates/install.rs
@@ -107,11 +107,11 @@ pub fn restart(executable: &Path) -> Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
-        Err(command.exec()).context("Could not restart OmaSend")
+        Err(command.exec()).context("Could not restart Omasend")
     }
     #[cfg(windows)]
     {
-        command.spawn().context("Could not restart OmaSend")?;
+        command.spawn().context("Could not restart Omasend")?;
         Ok(())
     }
 }

--- a/src/views/about.rs
+++ b/src/views/about.rs
@@ -38,7 +38,7 @@ impl Home {
                                 .flex_col()
                                 .flex_1()
                                 .gap_1()
-                                .child(dialog_title("OmaSend", cx))
+                                .child(dialog_title("Omasend", cx))
                                 .child(
                                     div()
                                         .text_color(theme.secondary)

--- a/src/views/home.rs
+++ b/src/views/home.rs
@@ -372,7 +372,7 @@ impl Home {
             files: true,
             directories: true,
             multiple: true,
-            prompt: Some(self.language.text("Add to OmaSend").into()),
+            prompt: Some(self.language.text("Add to Omasend").into()),
         });
         cx.spawn(async move |this, cx| {
             let result = prompt.await;
@@ -549,7 +549,7 @@ impl Render for Home {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         // Keep the application and popup controls in the same mono face.
         // Published gpui-omarchy defaults to the platform sans face; preserve
-        // any explicit theme font while adapting that fallback for OmaSend.
+        // any explicit theme font while adapting that fallback for Omasend.
         if cx.omarchy().font.as_ref() == ".SystemUIFont" {
             cx.global_mut::<gpui_omarchy::Theme>().font = if cfg!(target_os = "macos") {
                 "Menlo"
@@ -578,7 +578,7 @@ impl Render for Home {
             },
         );
         let mut root = focus_scope("omasend")
-            .key_context("OmaSend OmarchyFocusScope")
+            .key_context("Omasend OmarchyFocusScope")
             .track_focus(&self.focus)
             .size_full()
             .relative()
@@ -717,7 +717,7 @@ impl Render for Home {
                             MenuItem::new(self.language.text("Check for update"))
                                 .separator_before(),
                             MenuItem::new(self.language.text("About…")).separator_before(),
-                            MenuItem::new("OmaSend…"),
+                            MenuItem::new("Omasend…"),
                             MenuItem::new("GitHub…"),
                             MenuItem::new(self.language.text("Logs…")).separator_before(),
                             MenuItem::new(self.language.text("Exit")).separator_before(),

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -33,21 +33,21 @@ actions!(
 pub fn init(cx: &mut App) {
     cx.set_global(theme::ThemeMode::default());
     cx.bind_keys([
-        KeyBinding::new("ctrl-v", Paste, Some("OmaSend")),
-        KeyBinding::new("ctrl-o", OpenFiles, Some("OmaSend")),
-        KeyBinding::new("escape", Back, Some("OmaSend")),
-        KeyBinding::new("enter", Confirm, Some("OmaSend")),
-        KeyBinding::new("up", PreviousDevice, Some("OmaSend")),
-        KeyBinding::new("left", PreviousDevice, Some("OmaSend")),
-        KeyBinding::new("down", NextDevice, Some("OmaSend")),
-        KeyBinding::new("right", NextDevice, Some("OmaSend")),
+        KeyBinding::new("ctrl-v", Paste, Some("Omasend")),
+        KeyBinding::new("ctrl-o", OpenFiles, Some("Omasend")),
+        KeyBinding::new("escape", Back, Some("Omasend")),
+        KeyBinding::new("enter", Confirm, Some("Omasend")),
+        KeyBinding::new("up", PreviousDevice, Some("Omasend")),
+        KeyBinding::new("left", PreviousDevice, Some("Omasend")),
+        KeyBinding::new("down", NextDevice, Some("Omasend")),
+        KeyBinding::new("right", NextDevice, Some("Omasend")),
     ]);
     #[cfg(target_os = "macos")]
     cx.bind_keys([
-        KeyBinding::new("cmd-v", Paste, Some("OmaSend")),
-        KeyBinding::new("cmd-o", OpenFiles, Some("OmaSend")),
+        KeyBinding::new("cmd-v", Paste, Some("Omasend")),
+        KeyBinding::new("cmd-o", OpenFiles, Some("Omasend")),
         KeyBinding::new("cmd-q", Quit, None),
-        KeyBinding::new("cmd-w", CloseWindow, Some("OmaSend")),
+        KeyBinding::new("cmd-w", CloseWindow, Some("Omasend")),
     ]);
 }
 

--- a/src/views/updates.rs
+++ b/src/views/updates.rs
@@ -176,7 +176,7 @@ impl Home {
                 view.update_state = match result {
                     Ok(Ok(())) => UpdateState::Ready { version },
                     error => {
-                        tracing::error!(?error, "Could not install OmaSend update");
+                        tracing::error!(?error, "Could not install Omasend update");
                         UpdateState::InstallFailed { version }
                     }
                 };

--- a/tests/native_window.rs
+++ b/tests/native_window.rs
@@ -1,21 +1,21 @@
-//! Opt-in fixture for exercising a real OmaSend window against the official core.
+//! Opt-in fixture for exercising a real Omasend window against the official core.
 //! Run while the app is open: cargo test --no-default-features --test native_window -- --ignored --nocapture
 use omasend::localsend::{Node, NodeConfig, TransferEvent, Upload};
 use std::time::Duration;
 
 #[tokio::test]
-#[ignore = "requires a running OmaSend window and manual acceptance"]
+#[ignore = "requires a running Omasend window and manual acceptance"]
 async fn native_window_round_trip() {
     let downloads = tempfile::tempdir().unwrap();
     let peer = Node::start(NodeConfig {
-        alias: "OmaSend test peer".into(),
+        alias: "Omasend test peer".into(),
         port: 0,
         downloads: downloads.path().into(),
         discovery: true,
     })
     .await
     .unwrap();
-    let fixture = "OmaSend native window test\n";
+    let fixture = "Omasend native window test\n";
     let local_addresses: Vec<String> = if_addrs::get_if_addrs()
         .unwrap()
         .into_iter()
@@ -35,7 +35,7 @@ async fn native_window_round_trip() {
         match event {
             TransferEvent::DeviceFound(device)
                 if device.port == 53317
-                    && device.model == "OmaSend"
+                    && device.model == "Omasend"
                     && local_addresses.contains(&device.host)
                     && !offered =>
             {

--- a/website/README.md
+++ b/website/README.md
@@ -1,4 +1,4 @@
-# OmaSend website
+# Omasend website
 
 Static Astro site, following the Astro + Bun + GitHub Pages setup in `../gpui-omarchy/website`. Fonts are bundled locally. English lives at `/omasend/`, Simplified Chinese at `/omasend/zh-CN/`.
 
@@ -17,4 +17,4 @@ The default base is `/omasend`. Set `BASE_PATH` and `SITE_URL` together for anot
 
 Installer commands use `install.sh` and `install.ps1` from `main`; these become usable after the implementation is merged and a release is published. macOS downloads are `.tar.gz`, Linux `.tar.gz`, and Windows `.zip`.
 
-The network artwork is an illustration of local transfer, not a screenshot or a browser implementation of OmaSend. `public/icon.png` is copied unchanged from `assets/omasend.png`; its provenance is recorded in `assets/icon-provenance.txt`. The light/dark toggle follows the system until an explicit choice is saved, using Tokyo Night and Flexoki Light palettes. Language is selected from the header menu. The site does not claim mobile interoperability or Windows runtime testing has been completed.
+The network artwork is an illustration of local transfer, not a screenshot or a browser implementation of Omasend. `public/icon.png` is copied unchanged from `assets/omasend.png`; its provenance is recorded in `assets/icon-provenance.txt`. The light/dark toggle follows the system until an explicit choice is saved, using Tokyo Night and Flexoki Light palettes. Language is selected from the header menu. The site does not claim mobile interoperability or Windows runtime testing has been completed.

--- a/website/src/layouts/Home.astro
+++ b/website/src/layouts/Home.astro
@@ -33,13 +33,13 @@ const logoSegments = [
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={t.description} />
     <meta name="theme-color" content="#1a1b26" />
-    <title>OmaSend — {t.title}</title>
+    <title>Omasend — {t.title}</title>
     <link rel="canonical" href={canonical} />
     <link rel="alternate" hreflang="en" href={new URL(asset(''), Astro.site)} />
     <link rel="alternate" hreflang="zh-CN" href={new URL(asset('zh-CN/'), Astro.site)} />
     <link rel="alternate" hreflang="x-default" href={new URL(asset(''), Astro.site)} />
     <link rel="icon" type="image/svg+xml" href={asset('favicon.svg')} />
-    <meta property="og:title" content={`OmaSend — ${t.title}`} />
+    <meta property="og:title" content={`Omasend — ${t.title}`} />
     <meta property="og:description" content={t.description} />
     <meta property="og:type" content="website" />
     <meta property="og:url" content={canonical} />
@@ -54,7 +54,7 @@ const logoSegments = [
   <body>
     <a class="skip" href="#main">{t.skip}</a>
     <header><div class="shell nav-row">
-      <a href={asset(language === 'en' ? '' : 'zh-CN/')} class="brand" aria-label="OmaSend"><svg class="brand-mark" aria-hidden="true" viewBox="0 0 32 32" fill="currentColor"><path d="M4 2h6v4H6v4H2V6h2zM22 2h6v4h2v4h-4V6h-4zM2 22h4v4h4v4H4v-4H2zM26 22h4v4h-2v4h-6v-4h4z"/><path d="M12 4h8v2h-8zM26 12h2v8h-2zM12 26h8v2h-8zM4 12h2v8H4zM10 10h12v12H10z"/></svg>OmaSend</a>
+      <a href={asset(language === 'en' ? '' : 'zh-CN/')} class="brand" aria-label="Omasend"><svg class="brand-mark" aria-hidden="true" viewBox="0 0 32 32" fill="currentColor"><path d="M4 2h6v4H6v4H2V6h2zM22 2h6v4h2v4h-4V6h-4zM2 22h4v4h4v4H4v-4H2zM26 22h4v4h-2v4h-6v-4h4z"/><path d="M12 4h8v2h-8zM26 12h2v8h-2zM12 26h8v2h-8zM4 12h2v8H4zM10 10h12v12H10z"/></svg>Omasend</a>
       <nav aria-label={t.nav}>
         <a class="icon-control" href={repo} aria-label="GitHub" title="GitHub"><svg aria-hidden='true' fill='currentColor' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/></svg></a>
         <div class="language-control">
@@ -105,7 +105,7 @@ const logoSegments = [
       <section class="section details"><div class="section-heading"><span class="index" aria-hidden="true">02 /</span><h2>{t.details}</h2><p class="foundation"><a class="text-link" href="https://gpui-kit.com/">GPUI Kit ↗</a><br /><a class="text-link" href="https://huacnlee.github.io/gpui-omarchy/">GPUI Omarchy ↗</a><br /><a class="text-link" href="https://github.com/localsend/localsend">LocalSend Rust core ↗</a></p></div><dl>{t.facts.map(([title, body]) => <div><dt>{title}</dt><dd>{body}</dd></div>)}</dl></section>
 
     </main>
-    <footer><div class="shell"><span>OmaSend · {t.footer}</span><span>{t.built} <a class="text-link" href="https://gpui-kit.com/">GPUI Kit</a> · <a class="text-link" href="https://huacnlee.github.io/gpui-omarchy/">GPUI Omarchy</a> · <a class="text-link" href={repo}>{t.source}</a></span></div></footer>
+    <footer><div class="shell"><span>Omasend · {t.footer}</span><span>{t.built} <a class="text-link" href="https://gpui-kit.com/">GPUI Kit</a> · <a class="text-link" href="https://huacnlee.github.io/gpui-omarchy/">GPUI Omarchy</a> · <a class="text-link" href={repo}>{t.source}</a></span></div></footer>
     <script>
       const root = document.documentElement;
       const modeQuery = matchMedia('(prefers-color-scheme: light)');

--- a/website/src/lib/copy.ts
+++ b/website/src/lib/copy.ts
@@ -1,15 +1,15 @@
 export const copy = {
   en: {
-    description: 'OmaSend is a native desktop LocalSend client built for Omarchy. Send files, screenshots, recordings and text across your local network.',
+    description: 'Omasend is a native desktop LocalSend client built for Omarchy. Send files, screenshots, recordings and text across your local network.',
     skip: 'Skip to content', download: 'Download', source: 'Source', theme: 'Theme', language: 'Language', darkMode: 'Dark mode', nav: 'Main navigation',
     eyebrow: 'Native to your desktop.', title: 'Copy. Paste. Send.',
     intro: 'The things on your screen, on your other device. A native LocalSend client, built with GPUI Kit and GPUI Omarchy.',
-    get: 'Get OmaSend', explore: 'See how it works', note: 'Local network · Open source · No account',
+    get: 'Get Omasend', explore: 'See how it works', note: 'Local network · Open source · No account',
     illustration: 'Files travel directly between devices on your local network.',
     local: 'Your local network', desktop: 'Your desktop', peer: 'Nearby device', payload: 'screenshot.png',
     workflow: 'One familiar gesture.', workflowIntro: 'A screenshot, a recording, a folder, a thought. Everything starts in the same composer.',
     steps: [
-      ['Copy something.', 'Copy an image, a file or some text. You can also drag files and folders into OmaSend.'],
+      ['Copy something.', 'Copy an image, a file or some text. You can also drag files and folders into Omasend.'],
       ['Choose a device.', 'Open LocalSend on your other device, on the same network. Nearby devices appear automatically.'],
       ['Send it over.', 'Preview what you’re sending. Your recipient accepts the transfer; received files go to Downloads.'],
     ],
@@ -30,16 +30,16 @@ export const copy = {
     footer: 'An independent community project.', built: 'Built with',
   },
   'zh-CN': {
-    description: 'OmaSend 是为 Omarchy 打造的原生 LocalSend 桌面客户端，在局域网内发送文件、截图、录屏和文字。',
+    description: 'Omasend 是为 Omarchy 打造的原生 LocalSend 桌面客户端，在局域网内发送文件、截图、录屏和文字。',
     skip: '跳转到内容', download: '下载', source: '源码', theme: '主题', language: '语言', darkMode: '深色模式', nav: '主导航',
     eyebrow: '为你的桌面而生', title: '复制 粘贴 发送',
     intro: '把屏幕上的内容，送到另一台设备。使用 GPUI Kit 与 GPUI Omarchy 构建的原生 LocalSend 客户端。',
-    get: '获取 OmaSend', explore: '了解使用方式', note: '局域网传输 · 开源 · 无需账号',
+    get: '获取 Omasend', explore: '了解使用方式', note: '局域网传输 · 开源 · 无需账号',
     illustration: '文件通过局域网直接在设备之间传输。',
     local: '你的局域网', desktop: '你的电脑', peer: '附近设备', payload: 'screenshot.png',
     workflow: '一个熟悉的动作', workflowIntro: '截图、录屏、文件夹，或一段想法。都从同一个待发送区域开始。',
     steps: [
-      ['复制内容', '复制图片、文件或文字，也可以把文件和文件夹直接拖进 OmaSend。'],
+      ['复制内容', '复制图片、文件或文字，也可以把文件和文件夹直接拖进 Omasend。'],
       ['选择设备', '在同一网络的另一台设备上打开 LocalSend。附近设备会自动出现。'],
       ['发送过去', '预览即将发送的内容。对方确认后开始传输，收到的文件直接保存到下载目录。'],
     ],


### PR DESCRIPTION
## Summary

Fix the Windows installer test failure: mocks now mutate shared state across the installer's child script scope, so latest-release/download counts and shortcut assertions observe the actual calls. Delegate ordinary New-Object calls to PowerShell so Archive module autoloading still works.

Add ci.yml for main pushes and pull requests: macOS/Linux/Windows unit and integration tests, platform installer tests, macOS GPUI interaction tests, and formatting/Clippy. Run installer tests first for quick feedback.

Standardize display branding as Omasend across the app, website, packaging metadata, installer messages and documentation. Preserve existing application bundle paths, icon resource names and bundle identifiers for compatibility.

## Test Plan

- Reproduced the exact latest-release assertion failure with PowerShell 7.6.5 on macOS; all six offline installer scenarios pass after the fix (Windows environment simulated and Start menu path redirected to the fixture directory). Native Windows execution is covered by the new CI.
- Eight Unix installer tests pass.
- Rust fmt, Clippy, build, 38 headless tests and 16 GPUI tests pass.
- Website build and 12 Playwright tests pass.
- actionlint 1.7.12 passes for CI and release workflows.
