### PR TITLE
Use the gpui-kit facade and streamline CI on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  website:
+    name: Website build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.4.0'
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+        env:
+          SITE_URL: https://huacnlee.github.io
+          BASE_PATH: /omasend
+
   quality:
     name: Formatting and Clippy
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   quality:
     name: Formatting and Clippy
-    runs-on: macos-26
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -25,6 +25,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake clang pkg-config libssl-dev libfontconfig1-dev \
+            libfreetype6-dev libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
+            libvulkan-dev libxcb1-dev libx11-xcb-dev libzstd-dev
       - uses: Swatinem/rust-cache@v2
         with:
           key: ci-quality
@@ -32,12 +38,8 @@ jobs:
       - run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
   test:
-    name: Tests (${{ matrix.os }})
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-26, ubuntu-22.04, windows-2022]
-    runs-on: ${{ matrix.os }}
+    name: Tests (Linux)
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:
       CARGO_TERM_COLOR: always
@@ -50,22 +52,17 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install Linux dependencies
-        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev
+          sudo apt-get install -y cmake clang pkg-config libssl-dev libfontconfig1-dev \
+            libfreetype6-dev libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
+            libvulkan-dev libxcb1-dev libx11-xcb-dev libzstd-dev
       - uses: Swatinem/rust-cache@v2
         with:
           key: ci-tests
       - name: Unix installer tests
-        if: runner.os != 'Windows'
         run: python scripts/test-install.py
-      - name: Windows installer tests
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: ./scripts/test-install.ps1
       - name: Unit and integration tests
         run: cargo test --locked --no-default-features
       - name: GPUI interaction tests
-        if: runner.os == 'macOS'
         run: cargo test --locked --features ui-tests --bin omasend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,6 @@
 name: Release
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/release.yml'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'src/**'
-      - 'vendor/**'
-      - 'assets/**'
-      - 'packaging/**'
-      - 'scripts/**'
-      - 'install.sh'
-      - 'install.ps1'
   push:
     tags: ['v*']
   workflow_dispatch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3279d239b0b9228e04511ada0131120f1d7983147586e28a69820630755569f"
 dependencies = [
  "gpui-base",
+ "gpui-kit-assets",
  "gpui-pre",
  "gpui-pre-platform",
  "gpui-pre-reqwest-client",
@@ -2577,12 +2578,10 @@ dependencies = [
 
 [[package]]
 name = "gpui-omarchy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
- "gpui-base",
  "gpui-kit",
- "gpui-kit-assets",
  "toml 0.8.23",
 ]
 
@@ -4927,7 +4926,6 @@ dependencies = [
  "flate2",
  "futures-util",
  "gethostname",
- "gpui-base",
  "gpui-kit",
  "gpui-omarchy",
  "if-addrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ exclude = ["vendor/localsend", "vendor/gpui-omarchy"]
 
 [features]
 default = ["desktop"]
-desktop = ["dep:gpui-omarchy", "dep:gpui-base", "dep:gpui"]
-ui-tests = ["desktop", "gpui/test-support"]
+desktop = ["dep:gpui-omarchy", "dep:gpui-kit"]
+ui-tests = ["desktop", "gpui-kit/test-support"]
 
 [dependencies]
 anyhow = "1"
@@ -21,9 +21,8 @@ chrono = "0.4"
 cap-std = "3"
 dirs = "6"
 futures-util = "0.3"
-gpui-omarchy = { version = "=0.1.0", optional = true }
-gpui-base = { version = "=0.6.0", optional = true }
-gpui = { package = "gpui-kit", version = "=0.6.0", default-features = false, optional = true }
+gpui-omarchy = { version = "=0.1.1", optional = true }
+gpui-kit = { version = "=0.6.0", default-features = false, optional = true }
 localsend = { path = "vendor/localsend", features = ["discovery"] }
 if-addrs = "0.15"
 gethostname = "1.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,7 @@
 
 mod views;
 
-use gpui_omarchy::gpui::{
-    App, AppContext, Bounds, Entity, Global, WindowBounds, WindowOptions, px, size,
-};
+use gpui_kit::{App, AppContext, Bounds, Entity, Global, WindowBounds, WindowOptions, px, size};
 
 // On macOS the application session survives closing its last native window.
 // Reopening attaches the same entity, preserving the node and pending transfers.
@@ -77,8 +75,7 @@ fn main() -> anyhow::Result<()> {
         cx.on_action(|_: &views::Quit, cx| cx.quit());
         #[cfg(target_os = "macos")]
         cx.set_menus(vec![
-            gpui_omarchy::gpui::Menu::new("Omasend")
-                .items([gpui_omarchy::gpui::MenuItem::action("Exit", views::Quit)]),
+            gpui_kit::Menu::new("Omasend").items([gpui_kit::MenuItem::action("Exit", views::Quit)]),
         ]);
         #[cfg(not(target_os = "macos"))]
         cx.on_window_closed(|cx, _| {
@@ -102,11 +99,11 @@ fn main() -> anyhow::Result<()> {
 #[cfg(all(test, feature = "ui-tests"))]
 mod lifecycle_tests {
     use super::*;
-    use gpui_omarchy::gpui;
+    use gpui_kit::gpui;
 
     #[gpui::test]
     async fn closing_and_reopening_retains_session_without_duplicate_windows(
-        cx: &mut gpui::TestAppContext,
+        cx: &mut gpui_kit::TestAppContext,
     ) {
         // This exercises production preparation on Tokio's blocking pool. Its
         // completion wakes GPUI from a real worker thread, so opt into the test
@@ -128,9 +125,9 @@ mod lifecycle_tests {
                 window_handle: None,
                 modal_focus: cx.focus_handle(),
                 nearby_expanded: false,
-                nearby_scroll: gpui::UniformListScrollHandle::new(),
+                nearby_scroll: gpui_kit::UniformListScrollHandle::new(),
                 history_expanded: false,
-                history_scroll: gpui::ScrollHandle::new(),
+                history_scroll: gpui_kit::ScrollHandle::new(),
                 logs: None,
                 about_open: false,
                 update_state: Default::default(),

--- a/src/views/about.rs
+++ b/src/views/about.rs
@@ -1,5 +1,5 @@
 use super::Home;
-use gpui_omarchy::gpui::{AnyElement, Context, Window, div, prelude::*, px, rems};
+use gpui_kit::{AnyElement, Context, Window, div, prelude::*, px, rems};
 use gpui_omarchy::{
     ActiveTheme, ButtonVariant, IconName, button, dialog, dialog_popup, dialog_title, icon,
 };

--- a/src/views/history.rs
+++ b/src/views/history.rs
@@ -1,7 +1,5 @@
 use super::{Home, size_label};
-use gpui_omarchy::gpui::{
-    AnimationExt, AnyElement, Context, SharedString, Window, div, prelude::*, rems,
-};
+use gpui_kit::{AnimationExt, AnyElement, Context, SharedString, Window, div, prelude::*, rems};
 use gpui_omarchy::{ActiveTheme, ButtonVariant, IconName, button, icon, progress, sheet};
 use omasend::model::{Transfer, TransferStatus};
 

--- a/src/views/home.rs
+++ b/src/views/home.rs
@@ -1,6 +1,6 @@
 use super::*;
 use anyhow::{Context as _, Result};
-use gpui_omarchy::gpui::{
+use gpui_kit::{
     self, AnyElement, Context, ExternalPaths, FocusHandle, PathPromptOptions, Window, div,
     prelude::*, rems,
 };
@@ -19,17 +19,17 @@ pub struct Home {
     pub node: Option<Node>,
     pub runtime: tokio::runtime::Handle,
     pub focus: FocusHandle,
-    pub window_handle: Option<gpui::AnyWindowHandle>,
+    pub window_handle: Option<gpui_kit::AnyWindowHandle>,
     pub modal_focus: FocusHandle,
     pub nearby_expanded: bool,
-    pub nearby_scroll: gpui::UniformListScrollHandle,
+    pub nearby_scroll: gpui_kit::UniformListScrollHandle,
     pub history_expanded: bool,
-    pub history_scroll: gpui::ScrollHandle,
+    pub history_scroll: gpui_kit::ScrollHandle,
     pub logs: Option<super::logs::LogsPanel>,
     pub about_open: bool,
     pub update_state: omasend::updates::UpdateState,
     pub show_update_status: bool,
-    pub update_status_dismiss: Option<gpui::Task<()>>,
+    pub update_status_dismiss: Option<gpui_kit::Task<()>>,
     pub restore_focus: Option<FocusHandle>,
     pub preview: Option<String>,
     pub loading_input: bool,
@@ -53,9 +53,9 @@ impl Home {
             window_handle: Some(window.window_handle()),
             modal_focus: cx.focus_handle(),
             nearby_expanded: false,
-            nearby_scroll: gpui::UniformListScrollHandle::new(),
+            nearby_scroll: gpui_kit::UniformListScrollHandle::new(),
             history_expanded: false,
-            history_scroll: gpui::ScrollHandle::new(),
+            history_scroll: gpui_kit::ScrollHandle::new(),
             logs: None,
             about_open: false,
             update_state: Default::default(),
@@ -299,7 +299,7 @@ impl Home {
             let paths: Vec<_> = entries
                 .iter()
                 .filter_map(|entry| {
-                    if let gpui::ClipboardEntry::ExternalPaths(paths) = entry {
+                    if let gpui_kit::ClipboardEntry::ExternalPaths(paths) = entry {
                         Some(paths.0.iter().cloned())
                     } else {
                         None
@@ -313,19 +313,19 @@ impl Home {
                 return;
             }
             if let Some(image) = entries.iter().find_map(|entry| {
-                if let gpui::ClipboardEntry::Image(image) = entry {
+                if let gpui_kit::ClipboardEntry::Image(image) = entry {
                     Some(image)
                 } else {
                     None
                 }
             }) {
                 let mime = match image.format() {
-                    gpui::ImageFormat::Png => "image/png",
-                    gpui::ImageFormat::Jpeg => "image/jpeg",
-                    gpui::ImageFormat::Tiff => "image/tiff",
-                    gpui::ImageFormat::Webp => "image/webp",
-                    gpui::ImageFormat::Gif => "image/gif",
-                    gpui::ImageFormat::Bmp => "image/bmp",
+                    gpui_kit::ImageFormat::Png => "image/png",
+                    gpui_kit::ImageFormat::Jpeg => "image/jpeg",
+                    gpui_kit::ImageFormat::Tiff => "image/tiff",
+                    gpui_kit::ImageFormat::Webp => "image/webp",
+                    gpui_kit::ImageFormat::Gif => "image/gif",
+                    gpui_kit::ImageFormat::Bmp => "image/bmp",
                     _ => {
                         self.state.error = Some("Copy the image as PNG or JPEG".into());
                         cx.notify();
@@ -345,7 +345,7 @@ impl Home {
                 let items = entries
                     .into_iter()
                     .filter_map(|entry| {
-                        if let gpui::ClipboardEntry::String(value) = entry {
+                        if let gpui_kit::ClipboardEntry::String(value) = entry {
                             Some(SendItem::Text(value.text().clone()))
                         } else {
                             None
@@ -662,7 +662,7 @@ impl Render for Home {
                             .child(
                                 div()
                                     .text_color(theme.bright)
-                                    .font_weight(gpui::FontWeight::BOLD)
+                                    .font_weight(gpui_kit::FontWeight::BOLD)
                                     .child("Omasend"),
                             ),
                     )
@@ -817,7 +817,7 @@ impl Render for Home {
                                     .child(
                                         div()
                                             .flex_shrink_0()
-                                            .font_weight(gpui::FontWeight::BOLD)
+                                            .font_weight(gpui_kit::FontWeight::BOLD)
                                             .text_color(theme.bright)
                                             .child(self.language.text("Outbox")),
                                     )
@@ -958,7 +958,8 @@ impl Render for Home {
 #[cfg(all(test, feature = "ui-tests"))]
 mod keyboard_tests {
     use super::*;
-    use gpui::{KeyDownEvent, KeyUpEvent, Keystroke, TestAppContext};
+    use gpui_kit::gpui;
+    use gpui_kit::{KeyDownEvent, KeyUpEvent, Keystroke, TestAppContext};
 
     #[gpui::test]
     fn update_restart_preserves_outbox_and_check_does_not_interrupt_install(
@@ -1003,7 +1004,7 @@ mod keyboard_tests {
     }
     fn with_home(
         cx: &mut TestAppContext,
-        test: impl FnOnce(gpui::Entity<Home>, &mut gpui::VisualTestContext),
+        test: impl FnOnce(gpui_kit::Entity<Home>, &mut gpui_kit::VisualTestContext),
     ) {
         cx.update(|cx| {
             gpui_omarchy::init(cx);
@@ -1030,9 +1031,9 @@ mod keyboard_tests {
                 focus,
                 modal_focus: cx.focus_handle(),
                 nearby_expanded: false,
-                nearby_scroll: gpui::UniformListScrollHandle::new(),
+                nearby_scroll: gpui_kit::UniformListScrollHandle::new(),
                 history_expanded: false,
-                history_scroll: gpui::ScrollHandle::new(),
+                history_scroll: gpui_kit::ScrollHandle::new(),
                 logs: None,
                 about_open: false,
                 update_state: Default::default(),
@@ -1055,17 +1056,24 @@ mod keyboard_tests {
             cx.update(|window, cx| {
                 assert!(*cx.global::<ThemeMode>() == ThemeMode::System);
                 ThemeMode::Light.apply(window, cx);
-                assert_eq!(cx.omarchy().appearance, gpui_base::ThemeAppearance::Light);
+                assert_eq!(
+                    cx.omarchy().appearance,
+                    gpui_kit::base::ThemeAppearance::Light
+                );
                 ThemeMode::Dark.apply(window, cx);
-                assert_eq!(cx.omarchy().appearance, gpui_base::ThemeAppearance::Dark);
+                assert_eq!(
+                    cx.omarchy().appearance,
+                    gpui_kit::base::ThemeAppearance::Dark
+                );
                 ThemeMode::System.apply(window, cx);
                 if !cfg!(target_os = "linux") {
                     let light = matches!(
                         window.appearance(),
-                        gpui::WindowAppearance::Light | gpui::WindowAppearance::VibrantLight
+                        gpui_kit::WindowAppearance::Light
+                            | gpui_kit::WindowAppearance::VibrantLight
                     );
                     assert_eq!(
-                        cx.omarchy().appearance == gpui_base::ThemeAppearance::Light,
+                        cx.omarchy().appearance == gpui_kit::base::ThemeAppearance::Light,
                         light
                     );
                 }
@@ -1102,13 +1110,13 @@ mod keyboard_tests {
         let (view, cx) = cx.add_window_view(|_, _| MenuHarness { selected: None });
         cx.update(|window, cx| window.draw(cx).clear(cx));
         cx.simulate_click(
-            gpui::point(gpui::px(15.), gpui::px(12.)),
+            gpui_kit::point(gpui_kit::px(15.), gpui_kit::px(12.)),
             Default::default(),
         );
         cx.update(|window, cx| window.draw(cx).clear(cx));
         let parent = cx.debug_bounds("omarchy-menu-content").unwrap();
         cx.simulate_click(
-            parent.origin + gpui::point(gpui::px(24.), gpui::px(20.)),
+            parent.origin + gpui_kit::point(gpui_kit::px(24.), gpui_kit::px(20.)),
             Default::default(),
         );
         cx.update(|window, cx| window.draw(cx).clear(cx));
@@ -1120,7 +1128,7 @@ mod keyboard_tests {
             .debug_bounds("omarchy-submenu-content")
             .expect("Theme must open its flyout");
         cx.simulate_click(
-            child.origin + gpui::point(gpui::px(24.), gpui::px(50.)),
+            child.origin + gpui_kit::point(gpui_kit::px(24.), gpui_kit::px(50.)),
             Default::default(),
         );
         cx.update(|window, cx| window.draw(cx).clear(cx));
@@ -1391,7 +1399,7 @@ mod keyboard_tests {
             view.read_with(cx, |view, _| {
                 let scroll = &view.history_scroll;
                 assert!(
-                    scroll.max_offset().y > gpui::px(0.),
+                    scroll.max_offset().y > gpui_kit::px(0.),
                     "fixture must overflow the dock"
                 );
                 assert_eq!(
@@ -1440,7 +1448,7 @@ mod keyboard_tests {
             view.update_in(cx, |view, window, cx| view.open_history(window, cx));
             cx.update(|window, cx| window.draw(cx).clear(cx));
             cx.simulate_click(
-                gpui::point(gpui::px(10.), gpui::px(10.)),
+                gpui_kit::point(gpui_kit::px(10.), gpui_kit::px(10.)),
                 Default::default(),
             );
             cx.update(|window, cx| {
@@ -1480,7 +1488,7 @@ mod keyboard_tests {
                 let text = clipboard
                     .into_entries()
                     .filter_map(|entry| match entry {
-                        gpui::ClipboardEntry::String(value) => Some(value.text().clone()),
+                        gpui_kit::ClipboardEntry::String(value) => Some(value.text().clone()),
                         _ => None,
                     })
                     .collect::<Vec<_>>()

--- a/src/views/logs.rs
+++ b/src/views/logs.rs
@@ -1,5 +1,5 @@
 use super::Home;
-use gpui_omarchy::gpui::{
+use gpui_kit::{
     AnyElement, ClipboardItem, Context, ScrollHandle, Task, Window, div, prelude::*, rems,
 };
 use gpui_omarchy::{ActiveTheme, ButtonVariant, IconName, button, icon, sheet};
@@ -42,7 +42,7 @@ impl Home {
                     let text = omasend::diagnostics::snapshot();
                     if text != logs.text {
                         let following = (logs.scroll.offset().y + logs.scroll.max_offset().y).abs()
-                            <= gpui_omarchy::gpui::px(1.);
+                            <= gpui_kit::px(1.);
                         logs.text = text;
                         if following {
                             logs.scroll.scroll_to_bottom();

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -8,7 +8,7 @@ mod panels;
 pub mod theme;
 mod updates;
 
-use gpui_omarchy::gpui::{App, KeyBinding, actions};
+use gpui_kit::{App, KeyBinding, actions};
 pub use home::Home;
 
 // Application spacing uses a 4px grid, expressed in rems to follow text scale.

--- a/src/views/motion.rs
+++ b/src/views/motion.rs
@@ -1,6 +1,6 @@
 //! State-driven transitions and a segmented discovery indicator.
 //! GPUI automatically renders the final frame when reduced motion is enabled.
-use gpui_omarchy::gpui::Animation;
+use gpui_kit::Animation;
 use std::time::Duration;
 
 pub fn content_enter() -> Animation {
@@ -18,12 +18,12 @@ fn ease_out(t: f32) -> f32 {
 /// Animate theme-colored segments of the shared pixel emblem.
 /// The center stays fixed through each quick actuation burst and shared rest.
 pub fn discovery_logo(
-    color: gpui_omarchy::gpui::Hsla,
+    color: gpui_kit::Hsla,
     discovering: bool,
     revision: u64,
     size: f32,
-) -> gpui_omarchy::gpui::AnyElement {
-    use gpui_omarchy::gpui::{AnimationExt, SharedString, div, prelude::*, px};
+) -> gpui_kit::AnyElement {
+    use gpui_kit::{AnimationExt, SharedString, div, prelude::*, px};
     let mut root = div().relative().size(px(size)).flex_shrink_0();
     if discovering {
         root = root.child(
@@ -122,8 +122,8 @@ pub fn discovery_logo(
 }
 
 /// Transparent vector emblem, tinted by the active Omarchy theme.
-pub fn logo(size: f32, color: gpui_omarchy::gpui::Hsla) -> gpui_omarchy::gpui::Svg {
-    use gpui_omarchy::gpui::{Styled, px, svg};
+pub fn logo(size: f32, color: gpui_kit::Hsla) -> gpui_kit::Svg {
+    use gpui_kit::{Styled, px, svg};
     svg()
         .data(include_bytes!("../../assets/logo.svg"))
         .size(px(size))

--- a/src/views/nearby.rs
+++ b/src/views/nearby.rs
@@ -1,7 +1,5 @@
 use super::Home;
-use gpui_omarchy::gpui::{
-    self, AnyElement, Context, Pixels, SharedString, Window, div, prelude::*, rems,
-};
+use gpui_kit::{self, AnyElement, Context, Pixels, SharedString, Window, div, prelude::*, rems};
 use gpui_omarchy::{ActiveTheme, ButtonVariant, IconName, avatar, button, icon};
 
 impl Home {
@@ -29,7 +27,7 @@ impl Home {
                 )
                 .into_any_element()
         } else {
-            gpui::uniform_list(
+            gpui_kit::uniform_list(
                 "nearby-list",
                 rows,
                 cx.processor(move |view, range: std::ops::Range<usize>, _, cx| {
@@ -78,7 +76,7 @@ impl Home {
                             .gap_2()
                             .child(
                                 div()
-                                    .font_weight(gpui::FontWeight::BOLD)
+                                    .font_weight(gpui_kit::FontWeight::BOLD)
                                     .child(self.language.text("Nearby")),
                             )
                             .child(
@@ -113,7 +111,7 @@ impl Home {
                             .on_click(cx.listener(|view, _, _, cx| {
                                 view.nearby_expanded = !view.nearby_expanded;
                                 view.nearby_scroll
-                                    .scroll_to_item(0, gpui::ScrollStrategy::Top);
+                                    .scroll_to_item(0, gpui_kit::ScrollStrategy::Top);
                                 cx.notify();
                             })),
                         )
@@ -234,7 +232,7 @@ impl Home {
         {
             self.nearby_scroll.scroll_to_item(
                 index / nearby_layout(window).0,
-                gpui::ScrollStrategy::Center,
+                gpui_kit::ScrollStrategy::Center,
             );
         }
     }

--- a/src/views/panels.rs
+++ b/src/views/panels.rs
@@ -1,5 +1,5 @@
 use super::{Home, size_label};
-use gpui_omarchy::gpui::{
+use gpui_kit::{
     AnimationExt, AnyElement, Context, ObjectFit, SharedString, div, img, prelude::*, px, rems,
 };
 use gpui_omarchy::{
@@ -40,7 +40,7 @@ impl Home {
                     .child(
                         div()
                             .text_color(theme.bright)
-                            .font_weight(gpui_omarchy::gpui::FontWeight::BOLD)
+                            .font_weight(gpui_kit::FontWeight::BOLD)
                             .child(self.language.text("Drop something here")),
                     )
                     .child(
@@ -146,7 +146,7 @@ impl Home {
                     .when(item.is_image(), |row| {
                         row.child(
                             button(
-                                gpui_omarchy::gpui::SharedString::from(format!("preview-{id}")),
+                                gpui_kit::SharedString::from(format!("preview-{id}")),
                                 self.language.text("Preview…"),
                                 ButtonVariant::Secondary,
                                 cx,
@@ -164,7 +164,7 @@ impl Home {
                     .when(!active, |row| {
                         row.child(
                             button(
-                                gpui_omarchy::gpui::SharedString::from(format!("remove-{id}")),
+                                gpui_kit::SharedString::from(format!("remove-{id}")),
                                 self.language.text("Remove"),
                                 ButtonVariant::Secondary,
                                 cx,

--- a/src/views/theme.rs
+++ b/src/views/theme.rs
@@ -1,7 +1,5 @@
-use gpui_omarchy::{
-    Theme,
-    gpui::{App, Global, Window, WindowAppearance},
-};
+use gpui_kit::{App, Global, Window, WindowAppearance};
+use gpui_omarchy::Theme;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub enum ThemeMode {

--- a/src/views/updates.rs
+++ b/src/views/updates.rs
@@ -1,5 +1,5 @@
 use super::Home;
-use gpui_omarchy::gpui::{Context, Window};
+use gpui_kit::{Context, Window};
 use omasend::updates::UpdateState;
 
 impl Home {

--- a/vendor/gpui-omarchy/Cargo.toml
+++ b/vendor/gpui-omarchy/Cargo.toml
@@ -12,7 +12,7 @@
 [package]
 edition = "2024"
 name = "gpui-omarchy"
-version = "0.1.0"
+version = "0.1.1"
 build = false
 exclude = [
     "website/**",
@@ -47,25 +47,18 @@ path = "tests/interaction.rs"
 [dependencies.chrono]
 version = "0.4.45"
 
-[dependencies.gpui]
+[dependencies.gpui-kit]
 version = "=0.6.0"
+features = ["assets"]
 default-features = false
-package = "gpui-kit"
-
-[dependencies.gpui-base]
-version = "=0.6.0"
-
-[dependencies.gpui-kit-assets]
-version = "=0.6.0"
 
 [dependencies.toml]
 version = "0.8"
 
-[dev-dependencies.gpui]
+[dev-dependencies.gpui-kit]
 version = "=0.6.0"
 features = ["test-support"]
 default-features = false
-package = "gpui-kit"
 
 [dev-dependencies.tempfile]
 version = "3"

--- a/vendor/gpui-omarchy/Cargo.toml.orig
+++ b/vendor/gpui-omarchy/Cargo.toml.orig
@@ -1,6 +1,6 @@
 [package]
 name = "gpui-omarchy"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 exclude = ["website/**", "examples/gallery-wasm/**"]
 license = "MIT"
@@ -8,15 +8,13 @@ description = "A gpui-kit component library designed for the Omarchy system and 
 repository = "https://github.com/huacnlee/gpui-omarchy"
 
 [dependencies]
-gpui = { package = "gpui-kit", version = "=0.6.0", default-features = false }
-gpui-base = "=0.6.0"
-gpui-kit-assets = "=0.6.0"
+gpui-kit = { version = "=0.6.0", default-features = false, features = ["assets"] }
 toml = "0.8"
 chrono = "0.4.45"
 
 [dev-dependencies]
 tempfile = "3"
-gpui = { package = "gpui-kit", version = "=0.6.0", default-features = false, features = ["test-support"] }
+gpui-kit = { version = "=0.6.0", default-features = false, features = ["test-support"] }
 
 [profile.dev]
 debug = "limited"

--- a/vendor/gpui-omarchy/README.md
+++ b/vendor/gpui-omarchy/README.md
@@ -46,12 +46,12 @@ Add the library to your application:
 gpui-omarchy = "0.1.0"
 ```
 
-Use `gpui_omarchy::gpui` for GPUI types and `gpui_omarchy::application()` for the desktop entry point. These are provided through GPUI Kit with its component facade disabled. See the [complete quick start](examples/hello.rs).
+Use `gpui_kit` for GPUI types and `gpui_omarchy::application()` for the desktop entry point. These are provided through GPUI Kit with its component facade disabled. See the [complete quick start](examples/hello.rs).
 
 Call `gpui_omarchy::init(cx)` once at startup, then create components inside `Render`:
 
 ```rust,ignore
-use gpui_omarchy::gpui::ParentElement;
+use gpui_kit::ParentElement;
 use gpui_omarchy::{button, panel, ButtonVariant};
 
 panel("Workspace", cx).child(
@@ -80,7 +80,6 @@ Wrap a window or form in `focus_scope("app")` to enable Tab and Shift+Tab traver
 `popover` returns a base Popover with square styling and keyboard isolation inside its content. Escape dismisses it and restores focus. `collapsible(open, cx)` returns a base Collapsible: regular children remain visible, while its content appears only when expanded.
 
 `toast(id, cx)` returns a composable base Toast surface. Applications control its lifecycle, optionally using base ToastManager. The gallery displays notifications at the bottom right with Undo and Retry actions. Saved notifications expire after six seconds, with the timer paused during hover or focus; errors remain until handled manually.
-
 
 `avatar(initials, cx)` returns a square base Avatar. Set its image slot with `.image(avatar_image(source))`. The application decides whether to fall back to initials when image loading fails.
 

--- a/vendor/gpui-omarchy/UPSTREAM.txt
+++ b/vendor/gpui-omarchy/UPSTREAM.txt
@@ -5,9 +5,12 @@ Local patches:
 - src/focus.rs respects gpui-base modal focus traps during Tab/Shift+Tab traversal.
 - src/icon.rs exposes ChevronUp and Send; bundled SVGs are from Lucide
   (https://github.com/lucide-icons/lucide), licensed in assets/icons/LICENSE-lucide.
-All other library source is unchanged. Kept here so the application builds reproducibly
-until these fixes can be released upstream.
+Kept here so the application builds reproducibly until these fixes can be released upstream.
 
 Local patch: embed a theme-colored History icon for the transfer history entry.
 
 Local patch: menus support side-by-side choice flyouts with pointer and keyboard navigation.
+
+Local fork version 0.1.1: migrate to the gpui-kit 0.6 facade, including base
+and assets re-exports, matching the upstream 0.1.1 dependency convention while
+retaining the application-specific fixes above. No direct gpui or gpui-base dependency.

--- a/vendor/gpui-omarchy/examples/gallery/app.rs
+++ b/vendor/gpui-omarchy/examples/gallery/app.rs
@@ -1,10 +1,10 @@
-use gpui::{
+use gpui_kit::base::CheckboxState;
+use gpui_kit::{
     App, ClickEvent, Context, Entity, FocusHandle, FontWeight, KeyDownEvent, Window, WindowOptions,
     div, prelude::*, px, size,
 };
 #[cfg(not(target_family = "wasm"))]
-use gpui::{Bounds, WindowBounds};
-use gpui_base::CheckboxState;
+use gpui_kit::{Bounds, WindowBounds};
 use gpui_omarchy::*;
 #[cfg(not(target_family = "wasm"))]
 use std::time::Instant as GalleryInstant;
@@ -146,8 +146,8 @@ fn description(page: &str) -> &'static str {
 }
 
 struct Gallery {
-    workspace_name: Entity<gpui_base::input::InputState>,
-    workspace_draft: Entity<gpui_base::input::InputState>,
+    workspace_name: Entity<gpui_kit::base::input::InputState>,
+    workspace_draft: Entity<gpui_kit::base::input::InputState>,
     saved_workspace: String,
     theme_mode: usize,
     toolbar_position: usize,
@@ -159,25 +159,25 @@ struct Gallery {
     modal_trigger: FocusHandle,
     modal_result: String,
     menu_result: String,
-    slider_value: Entity<gpui_base::slider::SliderState>,
-    slider_range: Entity<gpui_base::slider::SliderState>,
-    slider_disabled: Entity<gpui_base::slider::SliderState>,
+    slider_value: Entity<gpui_kit::base::slider::SliderState>,
+    slider_range: Entity<gpui_kit::base::slider::SliderState>,
+    slider_disabled: Entity<gpui_kit::base::slider::SliderState>,
     navigation_focus: FocusHandle,
-    navigation_list: gpui::ListState,
+    navigation_list: gpui_kit::ListState,
     navigation_rows: Vec<(bool, &'static str)>,
     expanded: [bool; 3],
     collapse_open: bool,
     toast_message: Option<&'static str>,
     toast_saved: bool,
-    toast_lifecycle: gpui_base::ToastManager<u8, &'static str>,
-    toast_timer: Option<gpui::Task<()>>,
+    toast_lifecycle: gpui_kit::base::ToastManager<u8, &'static str>,
+    toast_timer: Option<gpui_kit::Task<()>>,
     toast_hovered: bool,
     toast_focused: bool,
     toast_focus: FocusHandle,
     current_page: usize,
-    number: Entity<gpui_base::input::InputState>,
-    input: Entity<gpui_base::input::InputState>,
-    textarea: Entity<gpui_base::input::TextareaState>,
+    number: Entity<gpui_kit::base::input::InputState>,
+    input: Entity<gpui_kit::base::input::InputState>,
+    textarea: Entity<gpui_kit::base::input::TextareaState>,
     page: &'static str,
     count: usize,
     checked: bool,
@@ -188,53 +188,56 @@ struct Gallery {
     sheet_open: bool,
     sheet_focus: FocusHandle,
     sheet_trigger: FocusHandle,
-    activity_scroll: gpui_base::VirtualListScrollHandle,
-    timeline_scroll: gpui::ScrollHandle,
-    activity_sizes: std::rc::Rc<Vec<gpui::Size<gpui::Pixels>>>,
+    activity_scroll: gpui_kit::base::VirtualListScrollHandle,
+    timeline_scroll: gpui_kit::ScrollHandle,
+    activity_sizes: std::rc::Rc<Vec<gpui_kit::Size<gpui_kit::Pixels>>>,
     activity_rendered: usize,
     pressed: bool,
     article_filters: [bool; 3],
     tab: usize,
     progress: f32,
-    calendar_state: Entity<gpui_base::CalendarState>,
-    tree_state: Entity<gpui_base::TreeState>,
-    otp_state: Entity<gpui_base::OtpState>,
+    calendar_state: Entity<gpui_kit::base::CalendarState>,
+    tree_state: Entity<gpui_kit::base::TreeState>,
+    otp_state: Entity<gpui_kit::base::OtpState>,
     otp_disabled: bool,
-    color_state: Entity<gpui_base::ColorPickerState>,
-    nav_state: Entity<gpui_base::NavStackState>,
+    color_state: Entity<gpui_kit::base::ColorPickerState>,
+    nav_state: Entity<gpui_kit::base::NavStackState>,
     date_picker_state: Entity<DatePickerState>,
-    dock_state: Entity<gpui_base::dock::DockArea>,
+    dock_state: Entity<gpui_kit::base::dock::DockArea>,
 }
 
 impl Gallery {
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let number = cx.new(|cx| gpui_base::input::InputState::new(window, cx).default_value("1"));
-        let input =
-            cx.new(|cx| gpui_base::input::InputState::new(window, cx).placeholder("Project name"));
+        let number =
+            cx.new(|cx| gpui_kit::base::input::InputState::new(window, cx).default_value("1"));
+        let input = cx.new(|cx| {
+            gpui_kit::base::input::InputState::new(window, cx).placeholder("Project name")
+        });
         let textarea = cx.new(|cx| {
-            gpui_base::input::TextareaState::new(window, cx)
+            gpui_kit::base::input::TextareaState::new(window, cx)
                 .rows(4)
                 .placeholder("Add notes")
         });
         let slider_value = cx.new(|_| {
-            gpui_base::slider::SliderState::new()
+            gpui_kit::base::slider::SliderState::new()
                 .step(5.)
                 .default_value(40.)
         });
         let slider_range = cx.new(|_| {
-            gpui_base::slider::SliderState::new()
+            gpui_kit::base::slider::SliderState::new()
                 .step(5.)
                 .default_value((20., 80.))
         });
-        let slider_disabled = cx.new(|_| gpui_base::slider::SliderState::new().default_value(60.));
+        let slider_disabled =
+            cx.new(|_| gpui_kit::base::slider::SliderState::new().default_value(60.));
         for state in [&slider_value, &slider_range] {
             cx.observe(state, |_, _, cx| cx.notify()).detach();
         }
         let workspace_name = cx.new(|cx| {
-            gpui_base::input::InputState::new(window, cx).default_value("Personal workspace")
+            gpui_kit::base::input::InputState::new(window, cx).default_value("Personal workspace")
         });
         let workspace_draft = cx.new(|cx| {
-            gpui_base::input::InputState::new(window, cx).default_value("Personal workspace")
+            gpui_kit::base::input::InputState::new(window, cx).default_value("Personal workspace")
         });
         for state in [&workspace_name, &workspace_draft] {
             cx.observe(state, |_, _, cx| cx.notify()).detach();
@@ -266,39 +269,39 @@ impl Gallery {
         for state in [&select_choice, &combo_choice] {
             cx.observe(state, |_, _, cx| cx.notify()).detach();
         }
-        let calendar_state =
-            cx.new(|cx| gpui_base::CalendarState::new(window, cx).disabled_matcher(vec![0, 6]));
+        let calendar_state = cx
+            .new(|cx| gpui_kit::base::CalendarState::new(window, cx).disabled_matcher(vec![0, 6]));
         cx.observe(&calendar_state, |_, _, cx| cx.notify()).detach();
         let tree_state = cx.new(|cx| {
-            gpui_base::TreeState::new(cx).items(vec![
-                gpui_base::TreeItem::new("documents", "Documents")
+            gpui_kit::base::TreeState::new(cx).items(vec![
+                gpui_kit::base::TreeItem::new("documents", "Documents")
                     .expanded(true)
-                    .child(gpui_base::TreeItem::new("brief", "Project brief.md"))
-                    .child(gpui_base::TreeItem::new("notes", "Meeting notes.md")),
-                gpui_base::TreeItem::new("projects", "Projects")
+                    .child(gpui_kit::base::TreeItem::new("brief", "Project brief.md"))
+                    .child(gpui_kit::base::TreeItem::new("notes", "Meeting notes.md")),
+                gpui_kit::base::TreeItem::new("projects", "Projects")
                     .expanded(true)
                     .child(
-                        gpui_base::TreeItem::new("website", "Website")
-                            .child(gpui_base::TreeItem::new("homepage", "Homepage.md"))
-                            .child(gpui_base::TreeItem::new("assets", "Assets.md")),
+                        gpui_kit::base::TreeItem::new("website", "Website")
+                            .child(gpui_kit::base::TreeItem::new("homepage", "Homepage.md"))
+                            .child(gpui_kit::base::TreeItem::new("assets", "Assets.md")),
                     ),
-                gpui_base::TreeItem::new("archive", "Archive (unavailable)").disabled(true),
+                gpui_kit::base::TreeItem::new("archive", "Archive (unavailable)").disabled(true),
             ])
         });
         cx.observe(&tree_state, |_, _, cx| cx.notify()).detach();
-        let otp_state = cx.new(|cx| gpui_base::OtpState::new(6, window, cx));
+        let otp_state = cx.new(|cx| gpui_kit::base::OtpState::new(6, window, cx));
         cx.observe(&otp_state, |_, _, cx| cx.notify()).detach();
         let accent = cx.omarchy().accent;
         let color_state =
-            cx.new(|cx| gpui_base::ColorPickerState::new(window, cx).default_value(accent));
+            cx.new(|cx| gpui_kit::base::ColorPickerState::new(window, cx).default_value(accent));
         cx.observe(&color_state, |_, _, cx| cx.notify()).detach();
-        let nav_state = cx.new(|_| gpui_base::NavStackState::new());
+        let nav_state = cx.new(|_| gpui_kit::base::NavStackState::new());
         let task_page = cx.new(|cx| NavigationPage {
             level: 2,
             next: None,
             navigation: nav_state.downgrade(),
             notes: cx.new(|cx| {
-                gpui_base::input::InputState::new(window, cx)
+                gpui_kit::base::input::InputState::new(window, cx)
                     .default_value("Check the narrow window layout before Friday.")
             }),
         });
@@ -306,16 +309,16 @@ impl Gallery {
             level: 1,
             next: Some(task_page),
             navigation: nav_state.downgrade(),
-            notes: cx.new(|cx| gpui_base::input::InputState::new(window, cx)),
+            notes: cx.new(|cx| gpui_kit::base::input::InputState::new(window, cx)),
         });
         let root_page = cx.new(|cx| NavigationPage {
             level: 0,
             next: Some(project_page),
             navigation: nav_state.downgrade(),
-            notes: cx.new(|cx| gpui_base::input::InputState::new(window, cx)),
+            notes: cx.new(|cx| gpui_kit::base::input::InputState::new(window, cx)),
         });
         nav_state.update(cx, |state, cx| {
-            state.push(root_page, gpui_base::NavMotion::Immediate, cx)
+            state.push(root_page, gpui_kit::base::NavMotion::Immediate, cx)
         });
         cx.observe(&nav_state, |_, _, cx| cx.notify()).detach();
         let date_picker_state = cx.new(|cx| DatePickerState::new(window, cx));
@@ -350,9 +353,9 @@ impl Gallery {
             slider_range,
             slider_disabled,
             navigation_focus: cx.focus_handle(),
-            navigation_list: gpui::ListState::new(
+            navigation_list: gpui_kit::ListState::new(
                 GROUPS.len() + components().count(),
-                gpui::ListAlignment::Top,
+                gpui_kit::ListAlignment::Top,
                 px(100.),
             ),
             navigation_rows: GROUPS
@@ -365,7 +368,7 @@ impl Gallery {
             collapse_open: false,
             toast_message: None,
             toast_saved: false,
-            toast_lifecycle: gpui_base::ToastManager::new(gpui_base::ToastMotion {
+            toast_lifecycle: gpui_kit::base::ToastManager::new(gpui_kit::base::ToastMotion {
                 duration: std::time::Duration::ZERO,
                 exit_duration: std::time::Duration::ZERO,
                 ..Default::default()
@@ -388,8 +391,8 @@ impl Gallery {
             sheet_open: false,
             sheet_focus: cx.focus_handle(),
             sheet_trigger: cx.focus_handle(),
-            activity_scroll: gpui_base::VirtualListScrollHandle::new(),
-            timeline_scroll: gpui::ScrollHandle::new(),
+            activity_scroll: gpui_kit::base::VirtualListScrollHandle::new(),
+            timeline_scroll: gpui_kit::ScrollHandle::new(),
             activity_sizes: std::rc::Rc::new(
                 (0..1000)
                     .map(|index| size(px(400.), px(if index % 5 == 0 { 44. } else { 28. })))
@@ -438,7 +441,7 @@ impl Gallery {
         modal: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         let state = if modal {
             &self.workspace_draft
@@ -518,8 +521,10 @@ impl Gallery {
                         .on_click(cx.listener(
                             move |this, _, window, cx| {
                                 if modal {
-                                    window
-                                        .dispatch_action(Box::new(gpui_base::actions::Cancel), cx);
+                                    window.dispatch_action(
+                                        Box::new(gpui_kit::base::actions::Cancel),
+                                        cx,
+                                    );
                                 } else {
                                     let value = this.saved_workspace.clone();
                                     this.workspace_name
@@ -546,7 +551,9 @@ impl Gallery {
                             move |this, _, window, cx| {
                                 if modal {
                                     window.dispatch_action(
-                                        Box::new(gpui_base::actions::Confirm { secondary: false }),
+                                        Box::new(gpui_kit::base::actions::Confirm {
+                                            secondary: false,
+                                        }),
                                         cx,
                                     );
                                 } else {
@@ -558,7 +565,7 @@ impl Gallery {
             )
     }
 
-    fn reset_form(&self, modal: bool, cx: &mut Context<Self>) -> gpui::Div {
+    fn reset_form(&self, modal: bool, cx: &mut Context<Self>) -> gpui_kit::Div {
         let t = cx.omarchy();
         div().flex().flex_col().gap(px(18.))
             .child(div().flex().items_center().gap(px(10.))
@@ -568,19 +575,23 @@ impl Gallery {
             .child(div().flex().justify_end().gap(px(8.))
                 .child(dialog_button(if modal { "modal-cancel" } else { "specimen-cancel" }, "Cancel", ButtonVariant::Secondary, cx)
                     .on_click(cx.listener(move |this, _, window, cx| {
-                        if modal { window.dispatch_action(Box::new(gpui_base::actions::Cancel), cx); }
+                        if modal { window.dispatch_action(Box::new(gpui_kit::base::actions::Cancel), cx); }
                         else { this.modal_result = "Workspace unchanged".into(); cx.notify(); }
                     })))
                 .child(dialog_button(if modal { "modal-confirm" } else { "specimen-confirm" }, "Reset", ButtonVariant::Danger, cx)
                     .on_click(cx.listener(move |this, _, window, cx| {
-                        if modal { window.dispatch_action(Box::new(gpui_base::actions::Confirm { secondary: false }), cx); }
+                        if modal { window.dispatch_action(Box::new(gpui_kit::base::actions::Confirm { secondary: false }), cx); }
                         else { this.reset_workspace(window, cx); }
                     }))))
     }
 }
 
 impl Gallery {
-    fn render_toggle_group(&self, mut content: gpui::Div, cx: &mut Context<Self>) -> gpui::Div {
+    fn render_toggle_group(
+        &self,
+        mut content: gpui_kit::Div,
+        cx: &mut Context<Self>,
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
 
         let labels = ["Draft", "In review", "Published"];
@@ -659,10 +670,10 @@ impl Gallery {
 impl Gallery {
     fn render_overview_example(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         let form = self.workspace_form(false, window, cx);
         content = content
@@ -672,7 +683,7 @@ impl Gallery {
                     .flex_wrap()
                     .items_start()
                     .gap(px(24.))
-                    .child(div().w(px(420.)).max_w(gpui::relative(1.)).child(form))
+                    .child(div().w(px(420.)).max_w(gpui_kit::relative(1.)).child(form))
                     .child(
                         div()
                             .w(px(220.))
@@ -743,7 +754,7 @@ impl Gallery {
                     .into_iter()
                     .map(|(page, label)| {
                         dialog_button(
-                            (gpui::ElementId::from("overview-open"), page),
+                            (gpui_kit::ElementId::from("overview-open"), page),
                             label,
                             ButtonVariant::Secondary,
                             cx,
@@ -759,17 +770,17 @@ impl Gallery {
     }
     fn render_popover_example(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         let target = cx.entity();
         content = content
             .child(
                 div()
                     .w(px(360.))
-                    .max_w(gpui::relative(1.))
+                    .max_w(gpui_kit::relative(1.))
                     .p(px(14.))
                     .bg(t.normal_fill())
                     .flex()
@@ -840,10 +851,10 @@ impl Gallery {
     }
     fn render_tooltip_example(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         let action = if self.pressed {
             "Remove from favorites"
@@ -854,7 +865,7 @@ impl Gallery {
             .child(
                 div()
                     .w(px(360.))
-                    .max_w(gpui::relative(1.))
+                    .max_w(gpui_kit::relative(1.))
                     .p(px(14.))
                     .bg(t.normal_fill())
                     .flex()
@@ -896,10 +907,10 @@ impl Gallery {
     }
     fn render_menu_example(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         let target = cx.entity();
         content = content
@@ -932,10 +943,10 @@ impl Gallery {
     }
     fn render_table_example(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         let records = [
             (
@@ -1030,8 +1041,8 @@ impl Gallery {
                     .child(
                         table("projects", cx)
                             .min_w(px(640.))
-                            .child(gpui_base::TableHeader::new("head").child(heading))
-                            .child(gpui_base::TableBody::new("body").children(
+                            .child(gpui_kit::base::TableHeader::new("head").child(heading))
+                            .child(gpui_kit::base::TableBody::new("body").children(
                                 records.into_iter().enumerate().map(
                                     |(index, (name, label, status, owner, updated, files))| {
                                         table_row(index, index + 2, cx)
@@ -1063,10 +1074,10 @@ impl Gallery {
     }
     fn render_button_example(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content.child(div().text_color(t.secondary).child("Appearance"));
         for (key, label, variant) in [
@@ -1090,7 +1101,7 @@ impl Gallery {
                     )))
                     .child(
                         button(
-                            (gpui::ElementId::from(key), "disabled"),
+                            (gpui_kit::ElementId::from(key), "disabled"),
                             "Unavailable",
                             variant,
                             cx,
@@ -1151,10 +1162,10 @@ impl Gallery {
     }
     fn render_tabs_example(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         let labels = ["Overview", "Activity", "Settings"];
         let target = cx.entity();
@@ -1176,7 +1187,7 @@ impl Gallery {
         );
         let mut body = div()
             .id("workspace-tab-panel")
-            .role(gpui::Role::TabPanel)
+            .role(gpui_kit::Role::TabPanel)
             .flex()
             .flex_col()
             .gap(px(14.))
@@ -1189,7 +1200,7 @@ impl Gallery {
                 body = body
                     .child(
                         div()
-                            .font_weight(gpui::FontWeight::BOLD)
+                            .font_weight(gpui_kit::FontWeight::BOLD)
                             .child("Personal workspace"),
                     )
                     .child(
@@ -1219,7 +1230,7 @@ impl Gallery {
                 body = body
                     .child(
                         div()
-                            .font_weight(gpui::FontWeight::BOLD)
+                            .font_weight(gpui_kit::FontWeight::BOLD)
                             .child("Recent activity"),
                     )
                     .child(
@@ -1272,13 +1283,13 @@ impl Gallery {
     }
     fn render_resizable_example(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content.child("Horizontal").child(div().w_full().h(px(300.)).border_1().border_color(t.border)
-                    .child(resizable("workspace-panes", gpui::Axis::Horizontal, cx)
+                    .child(resizable("workspace-panes", gpui_kit::Axis::Horizontal, cx)
                         .child(resizable_panel().size(px(220.)).size_range(px(140.)..px(420.))
                             .child(div().size_full().p(px(14.)).flex().flex_col().gap(px(10.))
                                 .child("Documents").child("Project brief.md").child("Meeting notes.md")))
@@ -1294,7 +1305,7 @@ impl Gallery {
                 .border_1()
                 .border_color(t.border)
                 .child(
-                    resizable("preview-console", gpui::Axis::Vertical, cx)
+                    resizable("preview-console", gpui_kit::Axis::Vertical, cx)
                         .child(
                             resizable_panel()
                                 .size(px(140.))
@@ -1332,10 +1343,10 @@ impl Gallery {
     }
     fn render_avatar_example(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content.child(
             div()
@@ -1387,10 +1398,10 @@ impl Gallery {
     }
     fn render_nav_stack_example(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content
                     .child(
@@ -1404,7 +1415,7 @@ impl Gallery {
                                     .disabled(self.nav_state.read(cx).depth() <= 1)
                                     .on_click(cx.listener(|this, _, _, cx| {
                                         this.nav_state.update(cx, |state, cx| {
-                                            state.pop(gpui_base::NavMotion::Immediate, cx);
+                                            state.pop(gpui_kit::base::NavMotion::Immediate, cx);
                                         });
                                     })),
                             )
@@ -1414,7 +1425,7 @@ impl Gallery {
                                     .disabled(self.nav_state.read(cx).forward_views().len() == 0)
                                     .on_click(cx.listener(|this, _, _, cx| {
                                         this.nav_state.update(cx, |state, cx| {
-                                            state.forward(gpui_base::NavMotion::Immediate, cx);
+                                            state.forward(gpui_kit::base::NavMotion::Immediate, cx);
                                         });
                                     })),
                             )
@@ -1437,10 +1448,10 @@ impl Gallery {
 impl Gallery {
     fn render_progress_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = content
             .child(format!("Progress: {:.0}%", self.progress))
             .child(progress("progress", self.progress, cx))
@@ -1470,10 +1481,10 @@ impl Gallery {
     }
     fn render_empty_state_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = if self.count == 0 {
             content.child(
                 empty_state(
@@ -1504,10 +1515,10 @@ impl Gallery {
     }
     fn render_badge_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         for (label, status) in [
             ("Idle", Status::Neutral),
             ("Applied", Status::Success),
@@ -1520,10 +1531,10 @@ impl Gallery {
     }
     fn render_keycap_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = content.child(
             div()
                 .flex()
@@ -1538,10 +1549,10 @@ impl Gallery {
     }
     fn render_separator_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content
             .child(div().text_color(t.secondary).child("Horizontal"))
@@ -1578,10 +1589,10 @@ impl Gallery {
     }
     fn render_panel_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = content.child(
             panel("Workspace", cx)
                 .child("Theme-aware surface with a title and composable children")
@@ -1591,10 +1602,10 @@ impl Gallery {
     }
     fn render_calendar_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content
             .child("Schedule a workspace review")
@@ -1615,7 +1626,7 @@ impl Gallery {
                 button("clear-date", "Clear date", ButtonVariant::Outline, cx).on_click(
                     cx.listener(|this, _, window, cx| {
                         this.calendar_state.update(cx, |state, cx| {
-                            state.set_date(gpui_base::Date::Single(None), window, cx)
+                            state.set_date(gpui_kit::base::Date::Single(None), window, cx)
                         });
                     }),
                 ),
@@ -1624,10 +1635,10 @@ impl Gallery {
     }
     fn render_date_picker_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content
             .child("Review date")
@@ -1641,10 +1652,10 @@ impl Gallery {
     }
     fn render_color_picker_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         let color = self.color_state.read(cx).value().unwrap_or(t.accent);
         content = content.child("Project label color")
@@ -1657,10 +1668,10 @@ impl Gallery {
     }
     fn render_tree_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content
             .child("Workspace files")
@@ -1683,10 +1694,10 @@ impl Gallery {
     }
     fn render_dock_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content
                     .child(button("reset-dock", "Reset layout", ButtonVariant::Outline, cx)
@@ -1700,10 +1711,10 @@ impl Gallery {
     }
     fn render_hover_card_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content
             .child("Workspace owner")
@@ -1738,10 +1749,10 @@ impl Gallery {
     }
     fn render_otp_input_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content
             .child("Verification code")
@@ -1790,10 +1801,10 @@ impl Gallery {
     }
     fn render_button_group_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         let labels = ["Top", "Right", "Bottom", "Left"];
         let target = cx.entity();
@@ -1829,10 +1840,10 @@ impl Gallery {
     }
     fn render_link_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = content
             .child(link(
                 "manual",
@@ -1853,10 +1864,10 @@ impl Gallery {
     }
     fn render_toggle_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = content.child(
             toggle("toggle", "Favorite panel", self.pressed, cx)
                 .child(icon(IconName::Star))
@@ -1869,12 +1880,12 @@ impl Gallery {
     }
     fn render_radio_page(
         &mut self,
-        content: gpui::Div,
+        content: gpui_kit::Div,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let theme = cx.omarchy().clone();
-        let mut options = gpui_base::RadioGroup::new("list-density")
+        let mut options = gpui_kit::base::RadioGroup::new("list-density")
             .aria_label("List density")
             .track_focus(&self.radio_focus.clone().tab_stop(true))
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, _, cx| {
@@ -1965,10 +1976,10 @@ impl Gallery {
     }
     fn render_switch_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = content
             .child(
                 switch("switch", "Show metadata", self.enabled, cx).on_change(change(cx.listener(
@@ -1987,10 +1998,10 @@ impl Gallery {
     }
     fn render_checkbox_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let state = if self.mixed {
             CheckboxState::Indeterminate
         } else if self.checked {
@@ -2029,10 +2040,10 @@ impl Gallery {
     }
     fn render_textarea_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = content
             .child("Workspace notes")
             .child(textarea("notes", &self.textarea, window, cx).max_w(px(520.)))
@@ -2041,10 +2052,10 @@ impl Gallery {
     }
     fn render_input_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = content
             .child("Workspace name")
             .child(input("workspace-name", &self.input, window, cx).max_w(px(380.)))
@@ -2079,10 +2090,10 @@ impl Gallery {
     }
     fn render_number_input_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = content
             .child("Quantity")
             .child(number_input(&self.number, cx))
@@ -2091,15 +2102,15 @@ impl Gallery {
     }
     fn render_pagination_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let listener = cx.listener(|this, page, _, cx| {
             this.current_page = *page;
             cx.notify();
         });
-        let state = gpui_base::PaginationState::new(self.current_page, 12)
+        let state = gpui_kit::base::PaginationState::new(self.current_page, 12)
             .on_change(move |page, window, cx| listener(&page, window, cx));
         content = content
             .child(format!("Page {} of 12", self.current_page))
@@ -2108,18 +2119,18 @@ impl Gallery {
     }
     fn render_accordion_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let mut sections = accordion("sections", cx);
         for (index, (title, description)) in [
                     ("Appearance", "Uses the current Omarchy system theme, with Tokyo Night as the fallback. Change the theme from the application menu."),
                     ("Keyboard navigation", "Tab moves between controls. Return or Space activates the focused control. Escape closes an open menu or dialog."),
                     ("Workspace data", "Changes in this gallery stay in memory for this session. Resetting an example does not remove files on disk."),
                 ].into_iter().enumerate() {
-                    sections = sections.child(gpui_base::AccordionItem::new().open(self.expanded[index])
-                        .header(gpui_base::AccordionHeader::new(accordion_trigger(("section", index), title, self.expanded[index], cx)
+                    sections = sections.child(gpui_kit::base::AccordionItem::new().open(self.expanded[index])
+                        .header(gpui_kit::base::AccordionHeader::new(accordion_trigger(("section", index), title, self.expanded[index], cx)
                             .debug_selector(move || format!("accordion-trigger-{index}"))
                             .on_change(change(cx.listener(move |this, next, _, cx| { this.expanded[index] = *next; cx.notify(); })))))
                         .panel(accordion_panel(cx).child(div().debug_selector(move || format!("accordion-panel-{index}")).child(description))));
@@ -2167,7 +2178,7 @@ impl Gallery {
                 0
             },
             message,
-            gpui_base::ToastOptions {
+            gpui_kit::base::ToastOptions {
                 timeout: (message != "Could not sync workspace")
                     .then_some(std::time::Duration::from_secs(6)),
             },
@@ -2306,10 +2317,10 @@ impl Gallery {
 
     fn render_toast_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content = content
             .child(
@@ -2350,10 +2361,10 @@ impl Gallery {
     }
     fn render_collapsible_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         content =
             content.child(
@@ -2402,10 +2413,10 @@ impl Gallery {
     }
     fn render_icon_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         _window: &mut Window,
         _cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         for (name, glyph) in [
             ("Check", IconName::Check),
             ("Minus", IconName::Minus),
@@ -2433,10 +2444,10 @@ impl Gallery {
     }
     fn render_slider_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = content
             .child(format!("Volume: {}", self.slider_value.read(cx).value()))
             .child(slider(&self.slider_value, false, window, cx))
@@ -2449,10 +2460,10 @@ impl Gallery {
     }
     fn render_dialog_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         let alert = self.page == "alert_dialog";
         let specimen = if alert {
@@ -2526,7 +2537,7 @@ impl Gallery {
             let popup = div()
                 .id("modal-surface")
                 .occlude()
-                .max_w(gpui::relative(0.9))
+                .max_w(gpui_kit::relative(0.9))
                 .child(dialog_popup(cx).w(px(460.)).child(body));
             let close = cx.listener(|this, confirmed: &bool, window, cx| {
                 this.modal_open = false;
@@ -2571,10 +2582,10 @@ impl Gallery {
     }
     fn render_select_page(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
         let searchable = self.page == "combobox";
         let state = if searchable {
@@ -2601,7 +2612,7 @@ impl Gallery {
             .child(
                 div()
                     .w(px(360.))
-                    .max_w(gpui::relative(1.))
+                    .max_w(gpui_kit::relative(1.))
                     .flex()
                     .flex_col()
                     .gap(px(8.))
@@ -2622,7 +2633,7 @@ impl Gallery {
             .child(
                 div()
                     .w(px(360.))
-                    .max_w(gpui::relative(1.))
+                    .max_w(gpui_kit::relative(1.))
                     .flex()
                     .flex_col()
                     .gap(px(8.))
@@ -2645,7 +2656,7 @@ impl Gallery {
         cx.notify();
     }
 
-    fn render_project_sheet(&self, cx: &mut Context<Self>) -> gpui_base::Sheet {
+    fn render_project_sheet(&self, cx: &mut Context<Self>) -> gpui_kit::base::Sheet {
         let surface = sheet_surface(cx)
             .debug_selector(|| "project-sheet".into())
             .child(dialog_title("Website refresh", cx))
@@ -2675,13 +2686,13 @@ impl Gallery {
 }
 
 impl Gallery {
-    fn render_text_view(&self, content: gpui::Div, cx: &App) -> gpui::Div {
+    fn render_text_view(&self, content: gpui_kit::Div, cx: &App) -> gpui_kit::Div {
         content.child(markdown("project-brief", "## Website refresh\n\nA clearer home for our **project documentation**. Keep navigation simple and preserve the reading experience.\n\n### Before launch\n\n- Review the introduction and installation steps.\n- Verify keyboard navigation in both themes.\n- Publish the release notes.\n\n> Changes should make the next step easier to understand.\n\nRun the gallery locally:\n\n```sh\ncargo run --example gallery\n```\n\nRead the [project source](https://github.com/huacnlee/gpui-omarchy) for usage examples.", cx))
             .child(separator(cx))
             .child(html("release-summary", "<h3>Release summary</h3><p><strong>Ready for review.</strong> The documentation is complete; launch follows the final keyboard check.</p><p><em>Updated by Alex Lee</em></p>", cx))
     }
 
-    fn render_horizontal_scrollbar(&self, content: gpui::Div, cx: &App) -> gpui::Div {
+    fn render_horizontal_scrollbar(&self, content: gpui_kit::Div, cx: &App) -> gpui_kit::Div {
         let t = cx.omarchy();
         content
             .child("Project timeline · Scroll horizontally")
@@ -2736,7 +2747,7 @@ impl Gallery {
                     )
                     .child(scrollbar(
                         "timeline-scrollbar",
-                        gpui_base::ScrollbarAxis::Horizontal,
+                        gpui_kit::base::ScrollbarAxis::Horizontal,
                         &self.timeline_scroll,
                         cx,
                     )),
@@ -2745,9 +2756,9 @@ impl Gallery {
 
     fn render_activity_list(
         &mut self,
-        mut content: gpui::Div,
+        mut content: gpui_kit::Div,
         cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    ) -> gpui_kit::Div {
         content = content.child("Sample activity · 1,000 events").child(
             div().flex().gap(px(8.)).children(
                 [
@@ -2760,7 +2771,7 @@ impl Gallery {
                         .debug_selector(move || id.into())
                         .on_click(cx.listener(move |this, _, _, cx| {
                             this.activity_scroll
-                                .scroll_to_item(index, gpui::ScrollStrategy::Top);
+                                .scroll_to_item(index, gpui_kit::ScrollStrategy::Top);
                             cx.notify();
                         }))
                 }),
@@ -2799,7 +2810,7 @@ impl Gallery {
         .track_scroll(&self.activity_scroll);
         content.child(div().relative().w_full().border_1().border_color(cx.omarchy().border)
             .debug_selector(|| "activity-viewport".into()).child(list)
-            .child(scrollbar("activity-scrollbar", gpui_base::ScrollbarAxis::Vertical, &self.activity_scroll, cx)))
+            .child(scrollbar("activity-scrollbar", gpui_kit::base::ScrollbarAxis::Vertical, &self.activity_scroll, cx)))
             .child(div().text_color(cx.omarchy().secondary).child("Scroll through the log or jump to either end. Longer events keep their full description."))
     }
 }
@@ -3006,7 +3017,7 @@ impl Render for Gallery {
                 cx.notify();
             }))
             .child(
-                gpui::list(self.navigation_list.clone(), {
+                gpui_kit::list(self.navigation_list.clone(), {
                     let view = cx.entity();
                     move |index, _, cx| {
                         view.update(cx, |this, cx| {
@@ -3081,7 +3092,7 @@ impl Render for Gallery {
                             .text_size(px(14.))
                             .font_weight(FontWeight::BOLD)
                             .flex_1()
-                            .on_mouse_down(gpui::MouseButton::Left, |_, window, _| {
+                            .on_mouse_down(gpui_kit::MouseButton::Left, |_, window, _| {
                                 window.start_window_move()
                             })
                             .child("GPUI Omarchy"),
@@ -3132,7 +3143,7 @@ impl Render for Gallery {
                                 }
                             },
                         )
-                        .anchor(gpui::Anchor::TopRight),
+                        .anchor(gpui_kit::Anchor::TopRight),
                     ),
             )
             .child(
@@ -3195,7 +3206,7 @@ impl Render for Gallery {
                         ),
                     ),
             )
-            .child(gpui_base::TextSelectionLayer)
+            .child(gpui_kit::base::TextSelectionLayer)
             .when(self.sheet_open, |root| {
                 root.child(self.render_project_sheet(cx))
             })
@@ -3205,8 +3216,8 @@ impl Render for Gallery {
     }
 }
 
-fn demo_dock_layout(cx: &mut App) -> gpui_base::dock::DockLayout {
-    use gpui_base::dock::DockLayout;
+fn demo_dock_layout(cx: &mut App) -> gpui_kit::base::dock::DockLayout {
+    use gpui_kit::base::dock::DockLayout;
     let files = cx.new(|cx| DemoDockPanel {
         title: "Files",
         focus: cx.focus_handle(),
@@ -3228,18 +3239,18 @@ struct DemoDockPanel {
     title: &'static str,
     focus: FocusHandle,
 }
-impl gpui::EventEmitter<gpui_base::dock::PanelEvent> for DemoDockPanel {}
-impl gpui::Focusable for DemoDockPanel {
+impl gpui_kit::EventEmitter<gpui_kit::base::dock::PanelEvent> for DemoDockPanel {}
+impl gpui_kit::Focusable for DemoDockPanel {
     fn focus_handle(&self, _: &App) -> FocusHandle {
         self.focus.clone()
     }
 }
-impl gpui_base::dock::Panel for DemoDockPanel {
+impl gpui_kit::base::dock::Panel for DemoDockPanel {
     fn panel_name(&self) -> &'static str {
         self.title
     }
 }
-impl gpui::Render for DemoDockPanel {
+impl gpui_kit::Render for DemoDockPanel {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .size_full()
@@ -3272,12 +3283,12 @@ impl gpui::Render for DemoDockPanel {
     }
 }
 
-fn gallery_avatar() -> std::sync::Arc<gpui::Image> {
-    static IMAGE: std::sync::OnceLock<std::sync::Arc<gpui::Image>> = std::sync::OnceLock::new();
+fn gallery_avatar() -> std::sync::Arc<gpui_kit::Image> {
+    static IMAGE: std::sync::OnceLock<std::sync::Arc<gpui_kit::Image>> = std::sync::OnceLock::new();
     IMAGE
         .get_or_init(|| {
-            std::sync::Arc::new(gpui::Image::from_bytes(
-                gpui::ImageFormat::Png,
+            std::sync::Arc::new(gpui_kit::Image::from_bytes(
+                gpui_kit::ImageFormat::Png,
                 include_bytes!("../assets/huacnlee.png").to_vec(),
             ))
         })
@@ -3287,10 +3298,10 @@ fn gallery_avatar() -> std::sync::Arc<gpui::Image> {
 struct NavigationPage {
     level: usize,
     next: Option<Entity<NavigationPage>>,
-    navigation: gpui::WeakEntity<gpui_base::NavStackState>,
-    notes: Entity<gpui_base::input::InputState>,
+    navigation: gpui_kit::WeakEntity<gpui_kit::base::NavStackState>,
+    notes: Entity<gpui_kit::base::input::InputState>,
 }
-impl gpui::Render for NavigationPage {
+impl gpui_kit::Render for NavigationPage {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let t = cx.omarchy().clone();
         let (title, description) = match self.level {
@@ -3346,7 +3357,7 @@ impl gpui::Render for NavigationPage {
                             (this.navigation.upgrade(), this.next.clone())
                         {
                             navigation.update(cx, |state, cx| {
-                                state.push(next, gpui_base::NavMotion::Immediate, cx)
+                                state.push(next, gpui_kit::base::NavMotion::Immediate, cx)
                             });
                         }
                     })),
@@ -3405,7 +3416,7 @@ fn install_panic_report() {
 #[cfg(not(target_family = "wasm"))]
 pub fn run() {
     install_panic_report();
-    gpui::platform::application().run(move |cx| {
+    gpui_kit::platform::application().run(move |cx| {
         gpui_omarchy::init(cx);
         cx.open_window(
             WindowOptions {
@@ -3463,7 +3474,8 @@ fn change<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::TestAppContext;
+    use gpui_kit::TestAppContext;
+    use gpui_kit::gpui;
 
     #[gpui::test]
     fn dialogs_cancel_confirm_and_restore_focus(cx: &mut TestAppContext) {
@@ -3842,7 +3854,7 @@ mod tests {
             let this = view.read(cx);
             assert!(this.input.read(cx).value().is_empty());
             assert_eq!(this.count, 0);
-            use gpui::Focusable;
+            use gpui_kit::Focusable;
             assert!(this.input.read(cx).focus_handle(cx).is_focused(window));
         });
         cx.simulate_input("New name");
@@ -3910,8 +3922,8 @@ mod tests {
 
     #[gpui::test]
     fn dock_drag_merges_tabs_without_losing_panels(cx: &mut TestAppContext) {
-        use gpui::MouseButton;
-        use gpui_base::dock::DockPlacement;
+        use gpui_kit::MouseButton;
+        use gpui_kit::base::dock::DockPlacement;
         cx.update(gpui_omarchy::init);
         let (view, cx) = cx.add_window_view(Gallery::new);
         view.update(cx, |this, cx| {
@@ -3925,7 +3937,7 @@ mod tests {
         let destination = cx.debug_bounds("dock-tab-Preview").unwrap().center();
         cx.simulate_mouse_down(source, MouseButton::Left, Default::default());
         cx.simulate_mouse_move(
-            source + gpui::point(px(12.), px(0.)),
+            source + gpui_kit::point(px(12.), px(0.)),
             Some(MouseButton::Left),
             Default::default(),
         );
@@ -4039,9 +4051,9 @@ mod tests {
                 window.draw(cx).clear(cx);
                 let state = view.read(cx).color_state.read(cx);
                 assert!(!state.is_open());
-                assert!(gpui::Focusable::focus_handle(state, cx).is_focused(window));
+                assert!(gpui_kit::Focusable::focus_handle(state, cx).is_focused(window));
                 if commit {
-                    assert_eq!(state.value(), Some(gpui::hsla(0., 1., 0.5, 1.)));
+                    assert_eq!(state.value(), Some(gpui_kit::hsla(0., 1., 0.5, 1.)));
                 } else {
                     assert_eq!(state.value(), original);
                 }
@@ -4127,7 +4139,7 @@ mod tests {
                     cx.simulate_click(close, Default::default());
                 }
                 _ => cx.simulate_click(
-                    root.origin + gpui::point(px(10.), px(10.)),
+                    root.origin + gpui_kit::point(px(10.), px(10.)),
                     Default::default(),
                 ),
             }
@@ -4182,12 +4194,12 @@ mod tests {
             cx.update(|window, cx| window.draw(cx).clear(cx));
         }
         let bounds = cx.debug_bounds("activity-viewport").unwrap();
-        let start = gpui::point(bounds.right() - px(5.), bounds.top() + px(6.));
-        let end = gpui::point(start.x, bounds.bottom() - px(12.));
-        cx.simulate_mouse_down(start, gpui::MouseButton::Left, Default::default());
+        let start = gpui_kit::point(bounds.right() - px(5.), bounds.top() + px(6.));
+        let end = gpui_kit::point(start.x, bounds.bottom() - px(12.));
+        cx.simulate_mouse_down(start, gpui_kit::MouseButton::Left, Default::default());
         cx.update(|window, cx| window.draw(cx).clear(cx));
-        cx.simulate_mouse_move(end, Some(gpui::MouseButton::Left), Default::default());
-        cx.simulate_mouse_up(end, gpui::MouseButton::Left, Default::default());
+        cx.simulate_mouse_move(end, Some(gpui_kit::MouseButton::Left), Default::default());
+        cx.simulate_mouse_up(end, gpui_kit::MouseButton::Left, Default::default());
         for _ in 0..2 {
             cx.update(|window, cx| window.draw(cx).clear(cx));
         }
@@ -4210,12 +4222,12 @@ mod tests {
             cx.update(|window, cx| window.draw(cx).clear(cx));
         }
         let bounds = cx.debug_bounds("timeline-viewport").unwrap();
-        let start = gpui::point(bounds.left() + px(20.), bounds.bottom() - px(5.));
-        let end = gpui::point(bounds.right() - px(12.), start.y);
-        cx.simulate_mouse_down(start, gpui::MouseButton::Left, Default::default());
+        let start = gpui_kit::point(bounds.left() + px(20.), bounds.bottom() - px(5.));
+        let end = gpui_kit::point(bounds.right() - px(12.), start.y);
+        cx.simulate_mouse_down(start, gpui_kit::MouseButton::Left, Default::default());
         cx.update(|window, cx| window.draw(cx).clear(cx));
-        cx.simulate_mouse_move(end, Some(gpui::MouseButton::Left), Default::default());
-        cx.simulate_mouse_up(end, gpui::MouseButton::Left, Default::default());
+        cx.simulate_mouse_move(end, Some(gpui_kit::MouseButton::Left), Default::default());
+        cx.simulate_mouse_up(end, gpui_kit::MouseButton::Left, Default::default());
         for _ in 0..2 {
             cx.update(|window, cx| window.draw(cx).clear(cx));
         }

--- a/vendor/gpui-omarchy/examples/hello.rs
+++ b/vendor/gpui-omarchy/examples/hello.rs
@@ -1,4 +1,4 @@
-use gpui_omarchy::gpui::{
+use gpui_kit::{
     AppContext, Context, IntoElement, ParentElement, Render, Styled, Window, WindowOptions,
 };
 use gpui_omarchy::{ActiveTheme, ButtonVariant, button, focus_scope, panel};

--- a/vendor/gpui-omarchy/src/button.rs
+++ b/vendor/gpui-omarchy/src/button.rs
@@ -1,16 +1,16 @@
 //! Button presentation that suppresses transient styles while disabled.
-use gpui::{
+use gpui_kit::base::{ButtonStyles, RoleOverride};
+use gpui_kit::{
     AnyElement, App, ClickEvent, ElementId, FocusHandle, InteractiveElement, Interactivity,
     IntoElement, ParentElement, RenderOnce, SharedString, StatefulInteractiveElement,
     StyleRefinement, Styled, Window,
 };
-use gpui_base::{ButtonStyles, RoleOverride};
 
 /// An Omarchy button backed by gpui-base's activation and focus behavior.
 /// Transient styles are applied only after the final disabled state is known.
 #[derive(IntoElement)]
 pub struct Button {
-    base: gpui_base::Button,
+    base: gpui_kit::base::Button,
     disabled: bool,
     hover: Option<Box<StyleRefinement>>,
     active: Option<Box<StyleRefinement>>,
@@ -20,7 +20,7 @@ pub struct Button {
 impl Button {
     pub fn new(id: impl Into<ElementId>) -> Self {
         Self {
-            base: gpui_base::Button::new(id),
+            base: gpui_kit::base::Button::new(id),
             disabled: false,
             hover: None,
             active: None,
@@ -83,7 +83,7 @@ impl Button {
     }
 }
 
-impl gpui_base::Selectable for Button {
+impl gpui_kit::base::Selectable for Button {
     fn selected(self, selected: bool) -> Self {
         Button::selected(self, selected)
     }
@@ -148,7 +148,8 @@ impl RenderOnce for Button {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{Context, Modifiers, MouseButton, Render, TestAppContext, div, point, px};
+    use gpui_kit::gpui;
+    use gpui_kit::{Context, Modifiers, MouseButton, Render, TestAppContext, div, point, px};
     #[gpui::test]
     fn disabled_button_suppresses_hover_and_pressed_geometry(cx: &mut TestAppContext) {
         cx.update(crate::init);

--- a/vendor/gpui-omarchy/src/button_group.rs
+++ b/vendor/gpui-omarchy/src/button_group.rs
@@ -1,10 +1,10 @@
 //! Exclusive settings and page navigation with one keyboard stop per group.
 use crate::{ActiveTheme, ChoiceItem};
-use gpui::{App, Context, ElementId, Entity, FocusHandle, KeyBinding, Window, prelude::*, px};
-use gpui_base::{
+use gpui_kit::base::{
     Radio, RadioGroup, Tabs,
     actions::{Confirm, SelectLeft, SelectRight},
 };
+use gpui_kit::{App, Context, ElementId, Entity, FocusHandle, KeyBinding, Window, prelude::*, px};
 use std::rc::Rc;
 
 type Change = Rc<dyn Fn(usize, &mut Window, &mut App)>;
@@ -97,7 +97,7 @@ pub fn button_group(
         .collect::<Vec<_>>();
     navigate(
         RadioGroup::new(id)
-            .axis(gpui::Axis::Horizontal)
+            .axis(gpui_kit::Axis::Horizontal)
             .flex()
             .flex_wrap()
             .gap(px(6.))
@@ -207,7 +207,7 @@ fn navigate<T: StatefulInteractiveElement + FluentBuilder>(
         });
     if !enabled.is_empty() {
         let pointer_focus = focus.clone();
-        root = root.on_mouse_down(gpui::MouseButton::Left, move |_, window, cx| {
+        root = root.on_mouse_down(gpui_kit::MouseButton::Left, move |_, window, cx| {
             pointer_focus.focus(window, cx)
         });
     }
@@ -254,7 +254,8 @@ fn step(cursor: &mut Cursor, enabled: &[usize], forward: bool, cx: &mut Context<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{Render, TestAppContext};
+    use gpui_kit::gpui;
+    use gpui_kit::{Render, TestAppContext};
     struct Harness {
         tab_list: bool,
         selected: usize,

--- a/vendor/gpui-omarchy/src/calendar.rs
+++ b/vendor/gpui-omarchy/src/calendar.rs
@@ -1,7 +1,7 @@
 //! Calendar presentation over gpui-base's date and view state.
 use crate::{ActiveTheme, IconName, icon};
-use gpui::{App, ElementId, Entity, Role, prelude::*, px};
-use gpui_base::{Calendar, CalendarItemKind, CalendarState};
+use gpui_kit::base::{Calendar, CalendarItemKind, CalendarState};
+use gpui_kit::{App, ElementId, Entity, Role, prelude::*, px};
 
 /// A calendar with selectable days, month/year navigation and range styling.
 /// Observe the supplied state or subscribe to base CalendarEvent::Selected.

--- a/vendor/gpui-omarchy/src/color_picker.rs
+++ b/vendor/gpui-omarchy/src/color_picker.rs
@@ -1,7 +1,7 @@
 //! Color editing backed by base's hex validation and synchronized HSLA state.
 use crate::{ActiveTheme, ButtonVariant, button, input, popover_surface, slider};
-use gpui::{App, ElementId, Entity, Focusable, Window, div, prelude::*, px};
-use gpui_base::{ColorPicker, ColorPickerState, Popup};
+use gpui_kit::base::{ColorPicker, ColorPickerState, Popup};
+use gpui_kit::{App, ElementId, Entity, Focusable, Window, div, prelude::*, px};
 
 pub fn color_picker(
     id: impl Into<ElementId>,
@@ -41,7 +41,7 @@ pub fn color_picker(
         )
         .on_click(|_, window, cx| {
             window.dispatch_action(
-                Box::new(gpui_base::actions::Confirm { secondary: false }),
+                Box::new(gpui_kit::base::actions::Confirm { secondary: false }),
                 cx,
             );
         });
@@ -130,7 +130,7 @@ pub fn color_picker(
 fn restore_committed_color(
     state: &mut ColorPickerState,
     window: &mut Window,
-    cx: &mut gpui::Context<ColorPickerState>,
+    cx: &mut gpui_kit::Context<ColorPickerState>,
 ) {
     if let Some(value) = state.value() {
         state.set_value(value, window, cx);
@@ -142,7 +142,8 @@ fn restore_committed_color(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{Context, Render, TestAppContext};
+    use gpui_kit::gpui;
+    use gpui_kit::{Context, Render, TestAppContext};
     struct Harness {
         state: Entity<ColorPickerState>,
         disabled: bool,
@@ -159,7 +160,7 @@ mod tests {
         cx.update(crate::init);
         let (view, cx) = cx.add_window_view(|window, cx| {
             let state = cx.new(|cx| {
-                ColorPickerState::new(window, cx).default_value(gpui::hsla(0., 1., 0.5, 1.))
+                ColorPickerState::new(window, cx).default_value(gpui_kit::hsla(0., 1., 0.5, 1.))
             });
             cx.observe(&state, |_, _, cx| cx.notify()).detach();
             Harness {
@@ -204,7 +205,7 @@ mod tests {
         cx.update(|window, cx| window.draw(cx).clear(cx));
         let opacity = cx.debug_bounds("color-channel-Opacity").unwrap();
         cx.simulate_click(
-            gpui::point(opacity.left() + opacity.size.width / 2., opacity.center().y),
+            gpui_kit::point(opacity.left() + opacity.size.width / 2., opacity.center().y),
             Default::default(),
         );
         cx.update(|window, cx| {
@@ -228,7 +229,7 @@ mod tests {
             window.draw(cx).clear(cx);
             let state = view.read(cx).state.read(cx);
             assert!(!state.is_open());
-            assert_eq!(state.value(), Some(gpui::hsla(1. / 3., 1., 0.5, 1.)));
+            assert_eq!(state.value(), Some(gpui_kit::hsla(1. / 3., 1., 0.5, 1.)));
             assert!(state.focus_handle(cx).is_focused(window));
         });
     }

--- a/vendor/gpui-omarchy/src/controls.rs
+++ b/vendor/gpui-omarchy/src/controls.rs
@@ -1,13 +1,13 @@
 //! Styled constructors retain gpui-base's controlled-state builder APIs.
 use crate::{ActiveTheme, Button, IconName, Link, icon};
-use gpui::prelude::FluentBuilder;
-use gpui::{
-    App, ElementId, FontWeight, InteractiveElement, ParentElement, SharedString,
-    StatefulInteractiveElement, Styled, div, px,
-};
-use gpui_base::{
+use gpui_kit::base::{
     Checkbox, CheckboxIndicator, CheckboxState, Radio, Switch, SwitchThumb, SwitchTrack, Tab, Tabs,
     Toggle,
+};
+use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::{
+    App, ElementId, FontWeight, InteractiveElement, ParentElement, SharedString,
+    StatefulInteractiveElement, Styled, div, px,
 };
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -264,9 +264,9 @@ pub fn toggle(
 
 /// A multi-choice toolbar. Compose independent `toggle` children; each retains
 /// its own keyboard focus and controlled pressed state.
-pub fn toggle_group(id: impl Into<ElementId>, cx: &App) -> gpui_base::ToggleGroup {
+pub fn toggle_group(id: impl Into<ElementId>, cx: &App) -> gpui_kit::base::ToggleGroup {
     let t = cx.omarchy();
-    gpui_base::ToggleGroup::new(id)
+    gpui_kit::base::ToggleGroup::new(id)
         .flex()
         .flex_wrap()
         .items_center()

--- a/vendor/gpui-omarchy/src/date_picker.rs
+++ b/vendor/gpui-omarchy/src/date_picker.rs
@@ -1,8 +1,8 @@
 use crate::{ButtonVariant, IconName, button, calendar, icon};
-use gpui::{
+use gpui_kit::base::{CalendarEvent, CalendarState, DatePicker, Popup};
+use gpui_kit::{
     App, Context, ElementId, Entity, FocusHandle, MouseButton, Window, div, prelude::*, px,
 };
-use gpui_base::{CalendarEvent, CalendarState, DatePicker, Popup};
 
 pub struct DatePickerState {
     pub calendar: Entity<CalendarState>,
@@ -53,19 +53,19 @@ impl DatePickerState {
 
 pub(crate) fn init(cx: &mut App) {
     cx.bind_keys([
-        gpui::KeyBinding::new(
+        gpui_kit::KeyBinding::new(
             "enter",
-            gpui_base::actions::Confirm { secondary: false },
+            gpui_kit::base::actions::Confirm { secondary: false },
             Some("OmarchyDatePicker"),
         ),
-        gpui::KeyBinding::new(
+        gpui_kit::KeyBinding::new(
             "space",
-            gpui_base::actions::Confirm { secondary: false },
+            gpui_kit::base::actions::Confirm { secondary: false },
             Some("OmarchyDatePicker"),
         ),
-        gpui::KeyBinding::new(
+        gpui_kit::KeyBinding::new(
             "escape",
-            gpui_base::actions::Cancel,
+            gpui_kit::base::actions::Cancel,
             Some("OmarchyDatePicker"),
         ),
     ]);
@@ -101,10 +101,10 @@ pub fn date_picker(
             // Route pointer activation through the base root so builder refinements
             // such as `.disabled(true)` govern both keyboard and mouse behavior.
             if open {
-                window.dispatch_action(Box::new(gpui_base::actions::Cancel), cx);
+                window.dispatch_action(Box::new(gpui_kit::base::actions::Cancel), cx);
             } else {
                 window.dispatch_action(
-                    Box::new(gpui_base::actions::Confirm { secondary: false }),
+                    Box::new(gpui_kit::base::actions::Confirm { secondary: false }),
                     cx,
                 );
             }
@@ -139,7 +139,8 @@ pub fn date_picker(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{Render, TestAppContext};
+    use gpui_kit::gpui;
+    use gpui_kit::{Render, TestAppContext};
 
     struct Harness {
         state: Entity<DatePickerState>,
@@ -203,7 +204,7 @@ mod tests {
             cx.update(|window, cx| window.draw(cx).clear(cx));
             // Header center + header half-height + section gap + weekday row
             // + one complete week + day half-height: select the second Saturday.
-            let day = next + gpui::point(px(0.), px(14. + 8. + 28. + 28. + 14.));
+            let day = next + gpui_kit::point(px(0.), px(14. + 8. + 28. + 28. + 14.));
             cx.simulate_click(day, Default::default());
             cx.update(|window, cx| {
                 window.draw(cx).clear(cx);
@@ -214,7 +215,7 @@ mod tests {
             });
             cx.simulate_click(trigger, Default::default());
             cx.update(|window, cx| window.draw(cx).clear(cx));
-            cx.simulate_click(gpui::point(px(500.), px(400.)), Default::default());
+            cx.simulate_click(gpui_kit::point(px(500.), px(400.)), Default::default());
             cx.update(|window, cx| {
                 window.draw(cx).clear(cx);
                 assert!(!view.read(cx).state.read(cx).is_open());

--- a/vendor/gpui-omarchy/src/dialog.rs
+++ b/vendor/gpui-omarchy/src/dialog.rs
@@ -1,7 +1,9 @@
 //! Modal presentation built from gpui-base's dialog hosts and content slots.
 use crate::ActiveTheme;
-use gpui::{App, FocusHandle, FontWeight, ParentElement, SharedString, Styled, px, rgb};
-use gpui_base::{AlertDialog, Dialog, DialogBackdrop, DialogDescription, DialogPopup, DialogTitle};
+use gpui_kit::base::{
+    AlertDialog, Dialog, DialogBackdrop, DialogDescription, DialogPopup, DialogTitle,
+};
+use gpui_kit::{App, FocusHandle, FontWeight, ParentElement, SharedString, Styled, px, rgb};
 
 /// Supply a stable focus handle, focus it on opening, and restore trigger focus on close.
 /// Base owns the focus trap, Escape, confirmation and backdrop dismissal.
@@ -26,7 +28,7 @@ pub fn dialog_backdrop() -> DialogBackdrop {
     DialogBackdrop::new()
         .absolute()
         .size_full()
-        .bg(gpui::Hsla::from(rgb(0)).opacity(0.6))
+        .bg(gpui_kit::Hsla::from(rgb(0)).opacity(0.6))
 }
 
 /// A single edged surface. Content slots and peer actions go inside this popup.
@@ -38,7 +40,7 @@ pub fn dialog_popup(cx: &App) -> DialogPopup {
         .flex_col()
         .gap(px(14.))
         .w(px(420.))
-        .max_w(gpui::relative(1.))
+        .max_w(gpui_kit::relative(1.))
         .p(px(18.))
         .border_1()
         .border_color(t.border)
@@ -65,7 +67,7 @@ pub fn dialog_description(text: impl Into<SharedString>, cx: &App) -> DialogDesc
 
 /// Outline actions for modal footers; semantic emphasis lives in the edge and label.
 pub fn dialog_button(
-    id: impl Into<gpui::ElementId>,
+    id: impl Into<gpui_kit::ElementId>,
     label: impl Into<SharedString>,
     variant: crate::ButtonVariant,
     cx: &App,

--- a/vendor/gpui-omarchy/src/dock.rs
+++ b/vendor/gpui-omarchy/src/dock.rs
@@ -1,7 +1,9 @@
 //! Dock presentation. Layout, reconciliation and drag operations stay in base.
 use crate::{ActiveTheme, ButtonVariant, button};
-use gpui::{AnyElement, App, Context, Div, SharedString, Stateful, Window, div, prelude::*, px};
-use gpui_base::dock::*;
+use gpui_kit::base::dock::*;
+use gpui_kit::{
+    AnyElement, App, Context, Div, SharedString, Stateful, Window, div, prelude::*, px,
+};
 use std::rc::Rc;
 
 pub fn dock_area(
@@ -92,10 +94,10 @@ impl TabGroupRenderer for OmarchyDock {
             .border_color(cx.omarchy().accent);
         Some(
             match indicator.placement() {
-                Some(gpui_base::Placement::Left) => hint.w(gpui::relative(0.5)),
-                Some(gpui_base::Placement::Right) => hint.left(gpui::relative(0.5)),
-                Some(gpui_base::Placement::Top) => hint.h(gpui::relative(0.5)),
-                Some(gpui_base::Placement::Bottom) => hint.top(gpui::relative(0.5)),
+                Some(gpui_kit::base::Placement::Left) => hint.w(gpui_kit::relative(0.5)),
+                Some(gpui_kit::base::Placement::Right) => hint.left(gpui_kit::relative(0.5)),
+                Some(gpui_kit::base::Placement::Top) => hint.h(gpui_kit::relative(0.5)),
+                Some(gpui_kit::base::Placement::Bottom) => hint.top(gpui_kit::relative(0.5)),
                 _ => hint,
             }
             .into_any_element(),
@@ -104,7 +106,7 @@ impl TabGroupRenderer for OmarchyDock {
 }
 
 struct DockDragLabel(&'static str);
-impl gpui::Render for DockDragLabel {
+impl gpui_kit::Render for DockDragLabel {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .px(px(10.))
@@ -120,6 +122,6 @@ impl gpui::Render for DockDragLabel {
 // Required by base's renderer contract; this skin offers tabbed/split docks only.
 impl TilesRenderer for OmarchyDock {
     fn render_drag_bar(&self, _: &TileContext, _: &mut Window, _: &mut App) -> AnyElement {
-        gpui::Empty.into_any_element()
+        gpui_kit::Empty.into_any_element()
     }
 }

--- a/vendor/gpui-omarchy/src/focus.rs
+++ b/vendor/gpui-omarchy/src/focus.rs
@@ -1,5 +1,5 @@
 //! Keyboard traversal for a composed desktop region.
-use gpui::{App, Div, ElementId, KeyBinding, Stateful, Window, actions, div, prelude::*};
+use gpui_kit::{App, Div, ElementId, KeyBinding, Stateful, Window, actions, div, prelude::*};
 
 actions!(omarchy_focus, [Next, Previous]);
 
@@ -11,7 +11,7 @@ pub(crate) fn init(cx: &mut App) {
             } else {
                 "ctrl-c"
             },
-            gpui_base::input::Copy,
+            gpui_kit::base::input::Copy,
             Some("OmarchyFocusScope"),
         ),
         KeyBinding::new("tab", Next, Some("OmarchyFocusScope")),
@@ -27,23 +27,23 @@ pub fn focus_scope(id: impl Into<ElementId>) -> Stateful<Div> {
         .id(id)
         .tab_group()
         .key_context("OmarchyFocusScope")
-        .on_action(|_: &gpui_base::input::Copy, window: &mut Window, cx| {
-            let selected = gpui_base::TextSelection::selected_text(window, cx);
+        .on_action(|_: &gpui_kit::base::input::Copy, window: &mut Window, cx| {
+            let selected = gpui_kit::base::TextSelection::selected_text(window, cx);
             if selected.is_empty() {
                 cx.propagate();
             } else {
-                cx.write_to_clipboard(gpui::ClipboardItem::new_string(selected));
+                cx.write_to_clipboard(gpui_kit::ClipboardItem::new_string(selected));
             }
         })
         .on_action(|_: &Next, window: &mut Window, cx| traverse(window, cx, false))
         .on_action(|_: &Previous, window: &mut Window, cx| traverse(window, cx, true))
         .on_action(
-            |_: &gpui_base::input::IndentInline, window: &mut Window, cx| {
+            |_: &gpui_kit::base::input::IndentInline, window: &mut Window, cx| {
                 traverse(window, cx, false)
             },
         )
         .on_action(
-            |_: &gpui_base::input::OutdentInline, window: &mut Window, cx| {
+            |_: &gpui_kit::base::input::OutdentInline, window: &mut Window, cx| {
                 traverse(window, cx, true)
             },
         )
@@ -52,7 +52,7 @@ pub fn focus_scope(id: impl Into<ElementId>) -> Stateful<Div> {
 // GPUI's window tab order includes background controls. Respect the modal
 // boundary registered by gpui-base before settling on the next tab stop.
 fn traverse(window: &mut Window, cx: &mut App, backwards: bool) {
-    let trap = gpui_base::active_focus_trap(window, cx);
+    let trap = gpui_kit::base::active_focus_trap(window, cx);
     let mut visited = Vec::new();
     loop {
         if backwards {

--- a/vendor/gpui-omarchy/src/hover_card.rs
+++ b/vendor/gpui-omarchy/src/hover_card.rs
@@ -1,6 +1,6 @@
 use crate::popover_surface;
-use gpui::{ElementId, IntoElement, ParentElement, Styled, prelude::*, px};
-use gpui_base::{HoverCard, HoverCardState};
+use gpui_kit::base::{HoverCard, HoverCardState};
+use gpui_kit::{ElementId, IntoElement, ParentElement, Styled, prelude::*, px};
 use std::time::Duration;
 
 /// Supplementary hover content. Keep essential information available inline.
@@ -9,8 +9,8 @@ pub fn hover_card<E: IntoElement>(
     trigger: impl IntoElement,
     content: impl FnOnce(
         &mut HoverCardState,
-        &mut gpui::Window,
-        &mut gpui::Context<HoverCardState>,
+        &mut gpui_kit::Window,
+        &mut gpui_kit::Context<HoverCardState>,
     ) -> E
     + 'static,
 ) -> HoverCard {

--- a/vendor/gpui-omarchy/src/icon.rs
+++ b/vendor/gpui-omarchy/src/icon.rs
@@ -1,6 +1,6 @@
 //! GPUI Kit's bundled icons, resolved against the current text color at render time.
-use gpui::{App, IntoElement, RenderOnce, StyleRefinement, Styled, Window, px, svg};
-use gpui_base::StyledExt;
+use gpui_kit::base::StyledExt;
+use gpui_kit::{App, IntoElement, RenderOnce, StyleRefinement, Styled, Window, px, svg};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum IconName {
@@ -74,7 +74,7 @@ fn icon_data(name: IconName) -> std::borrow::Cow<'static, [u8]> {
     if name == IconName::History {
         return std::borrow::Cow::Borrowed(include_bytes!("../assets/icons/history.svg"));
     }
-    gpui_kit_assets::Assets::get(name.path())
+    gpui_kit::assets::Assets::get(name.path())
         .expect("bundled icon exists")
         .data
 }

--- a/vendor/gpui-omarchy/src/input.rs
+++ b/vendor/gpui-omarchy/src/input.rs
@@ -1,12 +1,12 @@
 //! Native text editing, selection, clipboard and IME supplied by gpui-base.
 use crate::ActiveTheme;
-use gpui::{
-    App, ElementId, Entity, Focusable, InteractiveElement, MouseButton, ParentElement, Styled,
-    Window, px,
-};
-use gpui_base::{
+use gpui_kit::base::{
     Input, InputBase, Textarea,
     input::{InputState, TextareaState},
+};
+use gpui_kit::{
+    App, ElementId, Entity, Focusable, InteractiveElement, MouseButton, ParentElement, Styled,
+    Window, px,
 };
 
 fn frame(id: impl Into<ElementId>, focused: bool, cx: &App) -> InputBase {
@@ -66,15 +66,15 @@ pub fn textarea(
 }
 
 /// Numeric editing with native arrow-key stepping and paired step buttons.
-pub fn number_input(state: &Entity<InputState>, cx: &mut App) -> gpui_base::NumberInput {
-    use gpui::ParentElement as _;
+pub fn number_input(state: &Entity<InputState>, cx: &mut App) -> gpui_kit::base::NumberInput {
+    use gpui_kit::ParentElement as _;
     let t = cx.omarchy().clone();
     state.update(cx, |state, cx| {
         state.set_editor_style(t.input_style());
-        state.set_text_align(gpui::TextAlign::Center, cx);
+        state.set_text_align(gpui_kit::TextAlign::Center, cx);
     });
     let minus = t.clone();
-    gpui_base::NumberInput::new(state)
+    gpui_kit::base::NumberInput::new(state)
         .w(px(120.))
         .h(px(28.))
         .flex()
@@ -87,7 +87,7 @@ pub fn number_input(state: &Entity<InputState>, cx: &mut App) -> gpui_base::Numb
         .font_family(t.font.clone())
         .text_size(px(12.))
         .input(
-            gpui::div()
+            gpui_kit::div()
                 .flex_1()
                 .min_w_0()
                 .px(px(10.))

--- a/vendor/gpui-omarchy/src/lib.rs
+++ b/vendor/gpui-omarchy/src/lib.rs
@@ -4,10 +4,10 @@
 //! inside `Render`. They retain base builder APIs; Button adds disabled-state style gating.
 
 /// GPUI types and traits used to compose Omarchy applications.
-pub use gpui;
+pub use gpui_kit;
 /// Create an application using the current desktop platform.
 #[cfg(not(target_family = "wasm"))]
-pub use gpui::application;
+pub use gpui_kit::application;
 
 pub mod button;
 pub mod button_group;
@@ -70,8 +70,8 @@ pub use tooltip::{tooltip, with_tooltip};
 pub use tree::tree;
 
 /// Initialize base behavior and the current Omarchy theme (Tokyo Night when unavailable).
-pub fn init(cx: &mut gpui::App) {
-    gpui_base::init(cx);
+pub fn init(cx: &mut gpui_kit::App) {
+    gpui_kit::base::init(cx);
     focus::init(cx);
     button_group::init(cx);
     popover::init(cx);

--- a/vendor/gpui-omarchy/src/link.rs
+++ b/vendor/gpui-omarchy/src/link.rs
@@ -1,16 +1,16 @@
 //! Link presentation that suppresses transient styles while disabled.
-use gpui::{
+use gpui_kit::base::LinkStyles;
+use gpui_kit::{
     AnyElement, App, ClickEvent, ElementId, InteractiveElement, Interactivity, IntoElement,
     ParentElement, RenderOnce, SharedString, StatefulInteractiveElement, StyleRefinement, Styled,
     Window,
 };
-use gpui_base::LinkStyles;
 
 /// An Omarchy link backed by gpui-base's activation and focus behavior.
 /// Transient styles are applied only after the final disabled state is known.
 #[derive(IntoElement)]
 pub struct Link {
-    base: gpui_base::Link,
+    base: gpui_kit::base::Link,
     disabled: bool,
     hover: Option<Box<StyleRefinement>>,
     active: Option<Box<StyleRefinement>>,
@@ -20,7 +20,7 @@ pub struct Link {
 impl Link {
     pub fn new(id: impl Into<ElementId>) -> Self {
         Self {
-            base: gpui_base::Link::new(id),
+            base: gpui_kit::base::Link::new(id),
             disabled: false,
             hover: None,
             active: None,
@@ -131,7 +131,8 @@ impl RenderOnce for Link {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{Context, Modifiers, MouseButton, Render, TestAppContext, div, point, px};
+    use gpui_kit::gpui;
+    use gpui_kit::{Context, Modifiers, MouseButton, Render, TestAppContext, div, point, px};
     #[gpui::test]
     fn disabled_link_suppresses_hover_and_pressed_geometry(cx: &mut TestAppContext) {
         cx.update(crate::init);

--- a/vendor/gpui-omarchy/src/list.rs
+++ b/vendor/gpui-omarchy/src/list.rs
@@ -1,6 +1,6 @@
 //! Virtualized lists retain base's sizing and scroll model.
 use crate::ActiveTheme;
-use gpui::{
+use gpui_kit::{
     App, Context, ElementId, Entity, IntoElement, Pixels, Render, Size, Styled, Window, px,
 };
 use std::{ops::Range, rc::Rc};
@@ -14,9 +14,9 @@ pub fn virtual_list<V: Render, R: IntoElement>(
     sizes: Rc<Vec<Size<Pixels>>>,
     render: impl Fn(&mut V, Range<usize>, &mut Window, &mut Context<V>) -> Vec<R> + 'static,
     cx: &App,
-) -> gpui_base::VirtualList {
+) -> gpui_kit::base::VirtualList {
     let t = cx.omarchy();
-    gpui_base::v_virtual_list(view, id, sizes, render)
+    gpui_kit::base::v_virtual_list(view, id, sizes, render)
         .w_full()
         .h(px(280.))
         .font_family(t.font.clone())
@@ -27,17 +27,17 @@ pub fn virtual_list<V: Render, R: IntoElement>(
 
 /// Overlay scrollbar for a scrollable region. Render after that region inside a
 /// relative parent, using the same handle as the scrollable content.
-pub fn scrollbar<H: gpui_base::ScrollbarHandle + Clone>(
+pub fn scrollbar<H: gpui_kit::base::ScrollbarHandle + Clone>(
     id: impl Into<ElementId>,
-    axis: gpui_base::ScrollbarAxis,
+    axis: gpui_kit::base::ScrollbarAxis,
     handle: &H,
     cx: &App,
-) -> gpui_base::Scrollbar {
+) -> gpui_kit::base::Scrollbar {
     let t = cx.omarchy();
-    gpui_base::Scrollbar::new(handle)
+    gpui_kit::base::Scrollbar::new(handle)
         .id(id)
         .axis(axis)
-        .mode(gpui_base::ScrollbarMode::Always)
+        .mode(gpui_kit::base::ScrollbarMode::Always)
         .styles(|style| {
             style
                 .track(|track| track.width(px(8.)).bg(t.normal_fill()))

--- a/vendor/gpui-omarchy/src/menu.rs
+++ b/vendor/gpui-omarchy/src/menu.rs
@@ -1,10 +1,10 @@
 //! A keyboard menu composed from the base Popover and Button primitives.
 use crate::{ActiveTheme, ButtonVariant, IconName, button, icon};
-use gpui::{
+use gpui_kit::base::Popover;
+use gpui_kit::{
     App, ElementId, Focusable, KeyDownEvent, ParentElement, SharedString, Window, div, prelude::*,
     px,
 };
-use gpui_base::Popover;
 use std::rc::Rc;
 
 #[derive(Clone)]
@@ -60,7 +60,7 @@ impl MenuItem {
 /// Base positions the popup, dismisses outside/Escape and restores trigger focus.
 pub fn menu(
     id: impl Into<ElementId>,
-    trigger: impl gpui_base::Selectable + IntoElement + 'static,
+    trigger: impl gpui_kit::base::Selectable + IntoElement + 'static,
     items: Vec<MenuItem>,
     on_select: impl Fn(usize, &mut Window, &mut App) + 'static,
 ) -> Popover {
@@ -133,7 +133,7 @@ pub fn menu(
             let main = div()
                 .id("menu-items")
                 .debug_selector(|| "omarchy-menu-content".into())
-                .role(gpui::Role::Menu)
+                .role(gpui_kit::Role::Menu)
                 .track_focus(&focus)
                 .w(px(240.))
                 .p(px(6.))
@@ -146,7 +146,7 @@ pub fn menu(
                 .text_color(t.foreground)
                 .font_family(t.font.clone())
                 .text_size(px(12.))
-                .on_action(move |_: &gpui_base::actions::Confirm, window, cx| {
+                .on_action(move |_: &gpui_kit::base::actions::Confirm, window, cx| {
                     cx.stop_propagation();
                     if let Some(index) = *confirm_cursor.read(cx) {
                         confirm_select(index, window, cx);
@@ -224,13 +224,13 @@ pub fn menu(
                     let select = on_select.clone();
                     let row = button(("menu-item", index), "", ButtonVariant::Secondary, cx)
                         .accessibility_label(item.label.clone())
-                        .role(gpui::Role::MenuItem)
+                        .role(gpui_kit::Role::MenuItem)
                         .when_some(item.checked, |row, checked| {
-                            row.role(gpui::Role::MenuItemRadio)
+                            row.role(gpui_kit::Role::MenuItemRadio)
                                 .aria_toggled(if checked {
-                                    gpui::accesskit::Toggled::True
+                                    gpui_kit::accesskit::Toggled::True
                                 } else {
-                                    gpui::accesskit::Toggled::False
+                                    gpui_kit::accesskit::Toggled::False
                                 })
                         })
                         .focusable(false)
@@ -339,11 +339,11 @@ pub fn menu(
                                 let page = submenu_page.clone();
                                 button(("submenu-item", index), "", ButtonVariant::Secondary, cx)
                                     .accessibility_label(item.label.clone())
-                                    .role(gpui::Role::MenuItemRadio)
+                                    .role(gpui_kit::Role::MenuItemRadio)
                                     .aria_toggled(if item.checked == Some(true) {
-                                        gpui::accesskit::Toggled::True
+                                        gpui_kit::accesskit::Toggled::True
                                     } else {
-                                        gpui::accesskit::Toggled::False
+                                        gpui_kit::accesskit::Toggled::False
                                     })
                                     .focusable(false)
                                     .disabled(item.disabled)

--- a/vendor/gpui-omarchy/src/navigation.rs
+++ b/vendor/gpui-omarchy/src/navigation.rs
@@ -1,11 +1,11 @@
 //! Composable section navigation with gpui-base state and accessibility.
 use crate::{ActiveTheme, ButtonVariant, button};
-use gpui::{
+use gpui_kit::base::{
+    Accordion, AccordionPanel, AccordionTrigger, Pagination, PaginationItem, PaginationState,
+};
+use gpui_kit::{
     App, ElementId, FontWeight, InteractiveElement, IntoElement, ParentElement, SharedString,
     Styled, div, px,
-};
-use gpui_base::{
-    Accordion, AccordionPanel, AccordionTrigger, Pagination, PaginationItem, PaginationState,
 };
 
 pub fn accordion(id: impl Into<ElementId>, cx: &App) -> Accordion {
@@ -91,8 +91,8 @@ pub fn pagination(id: impl Into<ElementId>, state: PaginationState, cx: &App) ->
 
 /// A controlled expandable region. Ordinary children remain visible; `content`
 /// is rendered only while open. The caller owns the trigger and its state.
-pub fn collapsible(open: bool, cx: &App) -> gpui_base::Collapsible {
-    gpui_base::Collapsible::new()
+pub fn collapsible(open: bool, cx: &App) -> gpui_kit::base::Collapsible {
+    gpui_kit::base::Collapsible::new()
         .open(open)
         .flex()
         .flex_col()
@@ -103,9 +103,12 @@ pub fn collapsible(open: bool, cx: &App) -> gpui_base::Collapsible {
 }
 
 /// Stateful page navigation with the base push/pop/forward lifecycle.
-pub fn nav_stack(state: &gpui::Entity<gpui_base::NavStackState>, cx: &App) -> gpui_base::NavStack {
+pub fn nav_stack(
+    state: &gpui_kit::Entity<gpui_kit::base::NavStackState>,
+    cx: &App,
+) -> gpui_kit::base::NavStack {
     let t = cx.omarchy();
-    gpui_base::NavStack::new(state)
+    gpui_kit::base::NavStack::new(state)
         .w_full()
         .h(px(280.))
         .border_1()

--- a/vendor/gpui-omarchy/src/otp_input.rs
+++ b/vendor/gpui-omarchy/src/otp_input.rs
@@ -1,14 +1,14 @@
 use crate::ActiveTheme;
-use gpui::{App, Entity, Focusable, MouseButton, Window, div, prelude::*, px};
-use gpui_base::{OtpState, StyledExt as _};
+use gpui_kit::base::{OtpState, StyledExt as _};
+use gpui_kit::{App, Entity, Focusable, MouseButton, Window, div, prelude::*, px};
 
 /// Numeric code entry using base state, with clipboard support and inert disabled cells.
 #[derive(IntoElement)]
 pub struct OtpInput {
     state: Entity<OtpState>,
     disabled: bool,
-    style: gpui::StyleRefinement,
-    children: Vec<gpui::AnyElement>,
+    style: gpui_kit::StyleRefinement,
+    children: Vec<gpui_kit::AnyElement>,
 }
 impl OtpInput {
     pub fn disabled(mut self, disabled: bool) -> Self {
@@ -17,12 +17,12 @@ impl OtpInput {
     }
 }
 impl Styled for OtpInput {
-    fn style(&mut self) -> &mut gpui::StyleRefinement {
+    fn style(&mut self) -> &mut gpui_kit::StyleRefinement {
         &mut self.style
     }
 }
 impl ParentElement for OtpInput {
-    fn extend(&mut self, elements: impl IntoIterator<Item = gpui::AnyElement>) {
+    fn extend(&mut self, elements: impl IntoIterator<Item = gpui_kit::AnyElement>) {
         self.children.extend(elements);
     }
 }
@@ -122,9 +122,9 @@ impl RenderOnce for OtpInput {
                             if !next.is_empty() && next != state.value().as_ref() {
                                 let complete = next.len() == state.len();
                                 state.set_value(next, window, cx);
-                                cx.emit(gpui_base::OtpEvent::Change);
+                                cx.emit(gpui_kit::base::OtpEvent::Change);
                                 if complete {
-                                    cx.emit(gpui_base::OtpEvent::Complete);
+                                    cx.emit(gpui_kit::base::OtpEvent::Complete);
                                 }
                             }
                         });
@@ -158,9 +158,9 @@ impl RenderOnce for OtpInput {
                                 next.push_str(&digit);
                                 let complete = next.chars().count() == state.len();
                                 state.set_value(next, window, cx);
-                                cx.emit(gpui_base::OtpEvent::Change);
+                                cx.emit(gpui_kit::base::OtpEvent::Change);
                                 if complete {
-                                    cx.emit(gpui_base::OtpEvent::Complete);
+                                    cx.emit(gpui_kit::base::OtpEvent::Complete);
                                 }
                             }
                         });
@@ -170,7 +170,7 @@ impl RenderOnce for OtpInput {
                 }
             })
             .child(
-                gpui_base::OtpInput::new(&state)
+                gpui_kit::base::OtpInput::new(&state)
                     .flex()
                     .gap(px(6.))
                     .children(cells)
@@ -183,7 +183,8 @@ impl RenderOnce for OtpInput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{Context, Render, TestAppContext};
+    use gpui_kit::gpui;
+    use gpui_kit::{Context, Render, TestAppContext};
     struct Harness {
         state: Entity<OtpState>,
         disabled: bool,
@@ -233,7 +234,7 @@ mod tests {
             ("2", "３", "13"),
         ] {
             cx.update(|window, cx| {
-                let mut stroke = gpui::Keystroke::parse(key).unwrap();
+                let mut stroke = gpui_kit::Keystroke::parse(key).unwrap();
                 stroke.key_char = Some(character.into());
                 window.dispatch_keystroke(stroke, cx);
                 assert_eq!(view.read(cx).state.read(cx).value().as_ref(), expected);
@@ -252,9 +253,10 @@ mod tests {
         let events = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
         let seen = events.clone();
         view.update(cx, |this, cx| {
-            cx.subscribe(&this.state, move |_, _, event: &gpui_base::OtpEvent, _| {
-                seen.borrow_mut().push(*event)
-            })
+            cx.subscribe(
+                &this.state,
+                move |_, _, event: &gpui_kit::base::OtpEvent, _| seen.borrow_mut().push(*event),
+            )
             .detach();
         });
         cx.update(|window, cx| {
@@ -263,7 +265,7 @@ mod tests {
                 .read(cx)
                 .focus_handle(cx)
                 .focus(window, cx);
-            cx.write_to_clipboard(gpui::ClipboardItem::new_string("１２3-4567".into()));
+            cx.write_to_clipboard(gpui_kit::ClipboardItem::new_string("１２3-4567".into()));
             window.draw(cx).clear(cx);
         });
         let paste = if cfg!(target_os = "macos") {
@@ -277,7 +279,7 @@ mod tests {
             events
                 .borrow()
                 .iter()
-                .filter(|event| **event == gpui_base::OtpEvent::Complete)
+                .filter(|event| **event == gpui_kit::base::OtpEvent::Complete)
                 .count(),
             1
         );
@@ -286,7 +288,7 @@ mod tests {
             events
                 .borrow()
                 .iter()
-                .filter(|event| **event == gpui_base::OtpEvent::Complete)
+                .filter(|event| **event == gpui_kit::base::OtpEvent::Complete)
                 .count(),
             1
         );
@@ -297,7 +299,7 @@ mod tests {
             cx.notify();
         });
         cx.update(|window, cx| window.draw(cx).clear(cx));
-        cx.simulate_click(gpui::point(px(10.), px(10.)), Default::default());
+        cx.simulate_click(gpui_kit::point(px(10.), px(10.)), Default::default());
         cx.simulate_keystrokes("backspace 9");
         cx.simulate_keystrokes(paste);
         cx.update(|_, cx| assert_eq!(view.read(cx).state.read(cx).value().as_ref(), "12345"));
@@ -305,7 +307,7 @@ mod tests {
             window.blur(cx);
             window.draw(cx).clear(cx);
         });
-        cx.simulate_click(gpui::point(px(10.), px(10.)), Default::default());
+        cx.simulate_click(gpui_kit::point(px(10.), px(10.)), Default::default());
         cx.update(|window, cx| {
             assert!(
                 !view

--- a/vendor/gpui-omarchy/src/popover.rs
+++ b/vendor/gpui-omarchy/src/popover.rs
@@ -1,14 +1,14 @@
 //! Contextual controls in an anchored, non-modal surface.
 use crate::ActiveTheme;
-use gpui::{App, Context, Div, ElementId, Window, div, prelude::*, px};
-use gpui_base::{Popover, PopoverState};
+use gpui_kit::base::{Popover, PopoverState};
+use gpui_kit::{App, Context, Div, ElementId, Window, div, prelude::*, px};
 
 pub(crate) fn init(cx: &mut App) {
     // Suppress the outer Popover toggle bindings inside its content. Deeper
     // control contexts (Button, Input, Select) still retain their own bindings.
     cx.bind_keys([
-        gpui::KeyBinding::new("enter", gpui::NoAction, Some("OmarchyPopoverContent")),
-        gpui::KeyBinding::new("space", gpui::NoAction, Some("OmarchyPopoverContent")),
+        gpui_kit::KeyBinding::new("enter", gpui_kit::NoAction, Some("OmarchyPopoverContent")),
+        gpui_kit::KeyBinding::new("space", gpui_kit::NoAction, Some("OmarchyPopoverContent")),
     ]);
 }
 
@@ -19,7 +19,7 @@ pub(crate) fn init(cx: &mut App) {
 /// and compose `popover_surface(cx)` with your own dimensions and children.
 pub fn popover<E: IntoElement>(
     id: impl Into<ElementId>,
-    trigger: impl gpui_base::Selectable + IntoElement + 'static,
+    trigger: impl gpui_kit::base::Selectable + IntoElement + 'static,
     content: impl FnOnce(&mut PopoverState, &mut Window, &mut Context<PopoverState>) -> E + 'static,
 ) -> Popover {
     Popover::new(id)
@@ -40,7 +40,7 @@ pub fn popover_surface(cx: &App) -> Div {
         .flex_col()
         .gap(px(14.))
         .w(px(280.))
-        .max_w(gpui::relative(1.))
+        .max_w(gpui_kit::relative(1.))
         .p(px(14.))
         .border_1()
         .rounded(px(0.))
@@ -54,7 +54,8 @@ pub fn popover_surface(cx: &App) -> Div {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{FocusHandle, Render, TestAppContext};
+    use gpui_kit::gpui;
+    use gpui_kit::{FocusHandle, Render, TestAppContext};
     struct Harness {
         trigger: FocusHandle,
         checked: bool,
@@ -82,16 +83,16 @@ mod tests {
                                 "hidden",
                                 "Show hidden files",
                                 if checked {
-                                    gpui_base::CheckboxState::Checked
+                                    gpui_kit::base::CheckboxState::Checked
                                 } else {
-                                    gpui_base::CheckboxState::Unchecked
+                                    gpui_kit::base::CheckboxState::Unchecked
                                 },
                                 cx,
                             )
                             .track_focus(&checkbox_focus)
                             .on_change(move |value, _, _, cx| {
                                 target.update(cx, |state, cx| {
-                                    state.checked = value == gpui_base::CheckboxState::Checked;
+                                    state.checked = value == gpui_kit::base::CheckboxState::Checked;
                                     cx.notify();
                                 })
                             }),
@@ -127,13 +128,13 @@ mod tests {
                 "Tab should focus checkbox"
             )
         });
-        let keystroke = gpui::Keystroke::parse("space").unwrap();
-        cx.simulate_event(gpui::KeyDownEvent {
+        let keystroke = gpui_kit::Keystroke::parse("space").unwrap();
+        cx.simulate_event(gpui_kit::KeyDownEvent {
             keystroke: keystroke.clone(),
             is_held: false,
             prefer_character_input: false,
         });
-        cx.simulate_event(gpui::KeyUpEvent { keystroke });
+        cx.simulate_event(gpui_kit::KeyUpEvent { keystroke });
         cx.update(|window, cx| {
             window.draw(cx).clear(cx);
             assert!(view.read(cx).checked);

--- a/vendor/gpui-omarchy/src/resizable.rs
+++ b/vendor/gpui-omarchy/src/resizable.rs
@@ -1,6 +1,6 @@
 use crate::ActiveTheme;
-use gpui::{App, Axis, ElementId, div, prelude::*, px};
-use gpui_base::{ResizablePanel, ResizablePanelGroup};
+use gpui_kit::base::{ResizablePanel, ResizablePanelGroup};
+use gpui_kit::{App, Axis, ElementId, div, prelude::*, px};
 use std::rc::Rc;
 
 /// Resizable panes with a fine divider and base-owned drag hit area and limits.
@@ -28,14 +28,15 @@ pub fn resizable(id: impl Into<ElementId>, axis: Axis, cx: &App) -> ResizablePan
 }
 
 pub fn resizable_panel() -> ResizablePanel {
-    gpui_base::resizable_panel()
+    gpui_kit::base::resizable_panel()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{Context, Entity, MouseButton, Render, TestAppContext, Window, point};
-    use gpui_base::ResizableState;
+    use gpui_kit::base::ResizableState;
+    use gpui_kit::gpui;
+    use gpui_kit::{Context, Entity, MouseButton, Render, TestAppContext, Window, point};
     struct Harness {
         state: Entity<ResizableState>,
         axis: Axis,

--- a/vendor/gpui-omarchy/src/select.rs
+++ b/vendor/gpui-omarchy/src/select.rs
@@ -1,10 +1,10 @@
 //! Select and searchable Combobox presentations over the controlled base roots.
 use crate::{ActiveTheme, ButtonVariant, IconName, button, icon, input};
-use gpui::{
+use gpui_kit::base::{Combobox, ElementExt as _, Popup, Select, input::InputState};
+use gpui_kit::{
     App, Context, ElementId, Entity, FocusHandle, Focusable, SharedString, Window, div, prelude::*,
     px,
 };
-use gpui_base::{Combobox, ElementExt as _, Popup, Select, input::InputState};
 
 #[derive(Clone, Debug)]
 pub struct ChoiceItem {
@@ -40,16 +40,16 @@ pub struct ChoiceState {
     popup_focus: FocusHandle,
     query: Entity<InputState>,
     searchable: bool,
-    scroll: gpui::ScrollHandle,
-    popup_width: gpui::Pixels,
+    scroll: gpui_kit::ScrollHandle,
+    popup_width: gpui_kit::Pixels,
 }
 impl ChoiceState {
     pub fn new(items: Vec<ChoiceItem>, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let query = cx.new(|cx| InputState::new(window, cx).placeholder("Search options…"));
         cx.subscribe(
             &query,
-            |this, _, event: &gpui_base::input::InputEvent, cx| {
-                if !matches!(event, gpui_base::input::InputEvent::Change) {
+            |this, _, event: &gpui_kit::base::input::InputEvent, cx| {
+                if !matches!(event, gpui_kit::base::input::InputEvent::Change) {
                     return;
                 }
                 this.cursor = if this.query.read(cx).value().trim().is_empty() {
@@ -60,7 +60,7 @@ impl ChoiceState {
                         .into_iter()
                         .find(|&i| !this.items[i].disabled)
                 };
-                this.scroll.set_offset(gpui::point(px(0.), px(0.)));
+                this.scroll.set_offset(gpui_kit::point(px(0.), px(0.)));
                 cx.notify();
             },
         )
@@ -77,7 +77,7 @@ impl ChoiceState {
             popup_focus: cx.focus_handle(),
             query,
             searchable: false,
-            scroll: gpui::ScrollHandle::new(),
+            scroll: gpui_kit::ScrollHandle::new(),
             popup_width: px(280.),
         }
     }
@@ -334,7 +334,7 @@ fn presentation(
             .track_focus(&focus)
             .mt(px(4.))
             .w(popup_width)
-            .max_w(gpui::relative(1.))
+            .max_w(gpui_kit::relative(1.))
             .p(px(6.))
             .border_1()
             .border_color(t.control_border())
@@ -350,7 +350,7 @@ fn presentation(
                     state.set_open(false, window, cx);
                 })
             })
-            .on_action(move |_: &gpui_base::actions::Confirm, window, cx| {
+            .on_action(move |_: &gpui_kit::base::actions::Confirm, window, cx| {
                 cx.stop_propagation();
                 confirm.update(cx, |state, cx| state.commit(window, cx));
             });
@@ -364,7 +364,7 @@ fn presentation(
         }
         let mut rows = div()
             .id("choice-options")
-            .role(gpui::Role::ListBox)
+            .role(gpui_kit::Role::ListBox)
             .max_h(px(224.))
             .overflow_y_scroll()
             .track_scroll(&scroll)
@@ -386,7 +386,7 @@ fn presentation(
                 button(("choice-option", index), "", ButtonVariant::Secondary, cx)
                     .accessibility_label(item.label.clone())
                     .debug_selector(move || format!("omarchy-choice-option-{index}").into())
-                    .role(gpui::Role::ListBoxOption)
+                    .role(gpui_kit::Role::ListBoxOption)
                     .aria_selected(selected == Some(index))
                     .when(cursor == Some(index), |row| row.aria_active_descendant())
                     .focusable(false)
@@ -457,16 +457,16 @@ fn presentation(
             });
         }};
     }
-    action!(gpui_base::actions::Confirm, "enter");
-    action!(gpui_base::actions::Cancel, "escape");
-    action!(gpui_base::actions::SelectUp, "up");
-    action!(gpui_base::actions::SelectDown, "down");
-    action!(gpui_base::input::Enter, "enter");
-    action!(gpui_base::input::Escape, "escape");
-    action!(gpui_base::input::MoveUp, "up");
-    action!(gpui_base::input::MoveDown, "down");
-    action!(gpui_base::input::IndentInline, "tab");
-    action!(gpui_base::input::OutdentInline, "shift-tab");
+    action!(gpui_kit::base::actions::Confirm, "enter");
+    action!(gpui_kit::base::actions::Cancel, "escape");
+    action!(gpui_kit::base::actions::SelectUp, "up");
+    action!(gpui_kit::base::actions::SelectDown, "down");
+    action!(gpui_kit::base::input::Enter, "enter");
+    action!(gpui_kit::base::input::Escape, "escape");
+    action!(gpui_kit::base::input::MoveUp, "up");
+    action!(gpui_kit::base::input::MoveDown, "down");
+    action!(gpui_kit::base::input::IndentInline, "tab");
+    action!(gpui_kit::base::input::OutdentInline, "shift-tab");
     let target = state.clone();
     root.capture_key_down(move |event, window, cx| {
         if disabled {
@@ -513,7 +513,8 @@ fn presentation(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{Render, TestAppContext, VisualTestContext};
+    use gpui_kit::gpui;
+    use gpui_kit::{Render, TestAppContext, VisualTestContext};
     struct Harness {
         state: Entity<ChoiceState>,
         searchable: bool,
@@ -653,7 +654,10 @@ mod tests {
     fn disabled_choice_does_not_open(cx: &mut TestAppContext) {
         let (state, cx) = harness(cx, false, true);
         cx.simulate_keystrokes("down enter space");
-        cx.simulate_click(gpui::point(px(10.), px(10.)), gpui::Modifiers::default());
+        cx.simulate_click(
+            gpui_kit::point(px(10.), px(10.)),
+            gpui_kit::Modifiers::default(),
+        );
         cx.update(|_, cx| assert!(!state.read(cx).open));
     }
     #[gpui::test]
@@ -687,7 +691,7 @@ mod tests {
             window.draw(cx).clear(cx);
         });
         let row = cx.debug_bounds("omarchy-choice-option-2").unwrap();
-        cx.simulate_click(row.center(), gpui::Modifiers::default());
+        cx.simulate_click(row.center(), gpui_kit::Modifiers::default());
         cx.update(|window, cx| {
             window.draw(cx).clear(cx);
             assert!(!state.read(cx).open);
@@ -697,7 +701,10 @@ mod tests {
         cx.update(|window, cx| {
             window.draw(cx).clear(cx);
         });
-        cx.simulate_click(gpui::point(px(400.), px(400.)), gpui::Modifiers::default());
+        cx.simulate_click(
+            gpui_kit::point(px(400.), px(400.)),
+            gpui_kit::Modifiers::default(),
+        );
         cx.update(|window, cx| {
             window.draw(cx).clear(cx);
             assert!(!state.read(cx).open);

--- a/vendor/gpui-omarchy/src/sheet.rs
+++ b/vendor/gpui-omarchy/src/sheet.rs
@@ -1,10 +1,10 @@
 //! Edge-attached modal details, with dismissal and focus trapping owned by base.
 use crate::{ActiveTheme, dialog_backdrop};
-use gpui::{App, Div, FocusHandle, div, prelude::*, px, relative};
+use gpui_kit::{App, Div, FocusHandle, div, prelude::*, px, relative};
 
 /// Focus `focus` when opening; restore the trigger in `request_close`.
-pub fn sheet(focus: &FocusHandle, cx: &mut App) -> gpui_base::Sheet {
-    gpui_base::Sheet::new(cx)
+pub fn sheet(focus: &FocusHandle, cx: &mut App) -> gpui_kit::base::Sheet {
+    gpui_kit::base::Sheet::new(cx)
         .focus_handle(focus.clone())
         .overlay(dialog_backdrop())
 }

--- a/vendor/gpui-omarchy/src/slider.rs
+++ b/vendor/gpui-omarchy/src/slider.rs
@@ -1,11 +1,11 @@
 //! Horizontal single-value and range sliders with native pointer interaction.
 use crate::ActiveTheme;
-use gpui::{
-    App, Entity, FocusHandle, KeyDownEvent, MouseButton, Window, div, prelude::*, px, relative,
-};
-use gpui_base::{
+use gpui_kit::base::{
     Slider, SliderIndicator, SliderThumb, SliderTrack,
     slider::{SliderEvent, SliderState, SliderValue},
+};
+use gpui_kit::{
+    App, Entity, FocusHandle, KeyDownEvent, MouseButton, Window, div, prelude::*, px, relative,
 };
 
 /// Compose themed base parts. Pass disabled here so both track and thumbs are inert.
@@ -46,7 +46,7 @@ pub fn slider(
         let focus = window
             .use_keyed_state(
                 (
-                    gpui::ElementId::from(("omarchy-slider-focus", state.entity_id())),
+                    gpui_kit::ElementId::from(("omarchy-slider-focus", state.entity_id())),
                     if start { "start" } else { "end" },
                 ),
                 cx,

--- a/vendor/gpui-omarchy/src/surface.rs
+++ b/vendor/gpui-omarchy/src/surface.rs
@@ -1,9 +1,9 @@
 //! Dense, square surfaces and non-interactive information components.
 use crate::ActiveTheme;
-use gpui::{
+use gpui_kit::base::{Progress, ProgressIndicator, ProgressTrack};
+use gpui_kit::{
     App, Div, ElementId, FontWeight, ParentElement, SharedString, Styled, div, px, relative,
 };
-use gpui_base::{Progress, ProgressIndicator, ProgressTrack};
 
 pub fn panel(title: impl Into<SharedString>, cx: &App) -> Div {
     let t = cx.omarchy();
@@ -177,9 +177,9 @@ mod tests {
 
 /// Notification surface; compose actions and use gpui-base's ToastManager for
 /// application-owned stacking and timeout policy.
-pub fn toast(id: impl Into<gpui::ElementId>, cx: &App) -> gpui_base::Toast {
+pub fn toast(id: impl Into<gpui_kit::ElementId>, cx: &App) -> gpui_kit::base::Toast {
     let t = cx.omarchy();
-    gpui_base::Toast::new(id)
+    gpui_kit::base::Toast::new(id)
         .flex()
         .flex_col()
         .gap(px(10.))
@@ -196,9 +196,9 @@ pub fn toast(id: impl Into<gpui::ElementId>, cx: &App) -> gpui_base::Toast {
 
 /// A square identity marker. Supply initials or an icon in the fallback slot;
 /// callers can replace it with `avatar_image` through the base image builder.
-pub fn avatar(initials: impl Into<SharedString>, cx: &App) -> gpui_base::Avatar {
+pub fn avatar(initials: impl Into<SharedString>, cx: &App) -> gpui_kit::base::Avatar {
     let t = cx.omarchy();
-    gpui_base::Avatar::new()
+    gpui_kit::base::Avatar::new()
         .size(px(32.))
         .flex_shrink_0()
         .overflow_hidden()
@@ -210,7 +210,7 @@ pub fn avatar(initials: impl Into<SharedString>, cx: &App) -> gpui_base::Avatar 
         .text_size(px(12.))
         .text_color(t.foreground)
         .fallback(
-            gpui_base::AvatarFallback::new()
+            gpui_kit::base::AvatarFallback::new()
                 .size_full()
                 .flex()
                 .items_center()
@@ -221,6 +221,6 @@ pub fn avatar(initials: impl Into<SharedString>, cx: &App) -> gpui_base::Avatar 
 
 /// An image slot sized to its avatar. Image loading and failure policy remain
 /// with the application, matching gpui-base's explicit slot API.
-pub fn avatar_image(source: impl Into<gpui::ImageSource>) -> gpui_base::AvatarImage {
-    gpui_base::AvatarImage::new(source).size_full()
+pub fn avatar_image(source: impl Into<gpui_kit::ImageSource>) -> gpui_kit::base::AvatarImage {
+    gpui_kit::base::AvatarImage::new(source).size_full()
 }

--- a/vendor/gpui-omarchy/src/system_theme.rs
+++ b/vendor/gpui-omarchy/src/system_theme.rs
@@ -1,7 +1,7 @@
 //! Omarchy's current theme is a directory (or symlink), not an OS identity flag.
 use crate::Theme;
-use gpui::{Hsla, Rgba, rgb};
-use gpui_base::ThemeAppearance;
+use gpui_kit::base::ThemeAppearance;
+use gpui_kit::{Hsla, Rgba, rgb};
 use std::{fmt, fs, path::Path};
 
 #[derive(Debug)]
@@ -15,12 +15,12 @@ impl std::error::Error for ThemeLoadError {}
 
 #[cfg(not(target_family = "wasm"))]
 struct SystemThemeWatcher {
-    _task: gpui::Task<()>,
+    _task: gpui_kit::Task<()>,
 }
 #[cfg(not(target_family = "wasm"))]
-impl gpui::Global for SystemThemeWatcher {}
+impl gpui_kit::Global for SystemThemeWatcher {}
 
-pub(crate) fn stop_following(cx: &mut gpui::App) {
+pub(crate) fn stop_following(cx: &mut gpui_kit::App) {
     #[cfg(not(target_family = "wasm"))]
     if cx.try_global::<SystemThemeWatcher>().is_some() {
         cx.remove_global::<SystemThemeWatcher>();
@@ -33,7 +33,7 @@ impl Theme {
     /// Apply the system palette and follow changes until an explicit theme is applied.
     /// Native apps check once per second off the UI thread, following replaced symlinks.
     /// Browsers use the default palette without filesystem monitoring.
-    pub fn follow_system(cx: &mut gpui::App) {
+    pub fn follow_system(cx: &mut gpui_kit::App) {
         #[cfg(not(target_family = "wasm"))]
         Self::follow_system_from_home(std::env::var_os("HOME").map(Into::into), cx);
         #[cfg(target_family = "wasm")]
@@ -41,7 +41,7 @@ impl Theme {
     }
 
     #[cfg(not(target_family = "wasm"))]
-    fn follow_system_from_home(home: Option<std::path::PathBuf>, cx: &mut gpui::App) {
+    fn follow_system_from_home(home: Option<std::path::PathBuf>, cx: &mut gpui_kit::App) {
         let mut previous = Self::system_from_home(home.as_deref());
         previous.clone().apply(cx);
         let task = cx.spawn(async move |cx| {
@@ -213,11 +213,12 @@ fn contrast(a: Hsla, b: Hsla) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui_kit::gpui;
     const ANSI: &str = "background = '#fffcf0'\nforeground = '#100f0f'\naccent = '#205ea6'\ncolor1 = '#af3029'\ncolor2 = '#526600'\ncolor3 = '#855b00'\n";
     #[cfg(unix)]
     #[gpui::test]
     fn following_system_tracks_symlink_replacement_edits_and_recovery(
-        cx: &mut gpui::TestAppContext,
+        cx: &mut gpui_kit::TestAppContext,
     ) {
         let home = tempfile::tempdir().unwrap();
         let current = home.path().join(".local/state/omarchy/current");
@@ -230,7 +231,7 @@ mod tests {
         }
         std::os::unix::fs::symlink(&first, current.join("theme")).unwrap();
         cx.update(|cx| {
-            gpui_base::init(cx);
+            gpui_kit::base::init(cx);
             Theme::follow_system_from_home(Some(home.path().into()), cx);
         });
         cx.run_until_parked();
@@ -261,7 +262,7 @@ mod tests {
             assert_eq!(cx.global::<Theme>().name.as_ref(), "Recovered");
             assert_eq!(cx.global::<Theme>().accent, Hsla::from(rgb(0x205ea6)));
             assert_eq!(
-                gpui_base::Theme::global(cx).tokens.colors.primary,
+                gpui_kit::base::Theme::global(cx).tokens.colors.primary,
                 Hsla::from(rgb(0x205ea6))
             );
         });
@@ -270,14 +271,14 @@ mod tests {
     #[cfg(not(target_family = "wasm"))]
     #[gpui::test]
     fn explicit_theme_stops_following_and_system_can_be_selected_again(
-        cx: &mut gpui::TestAppContext,
+        cx: &mut gpui_kit::TestAppContext,
     ) {
         let home = tempfile::tempdir().unwrap();
         let current = home.path().join(".local/state/omarchy/current/theme");
         fs::create_dir_all(&current).unwrap();
         fs::write(current.join("colors.toml"), ANSI).unwrap();
         cx.update(|cx| {
-            gpui_base::init(cx);
+            gpui_kit::base::init(cx);
             Theme::follow_system_from_home(Some(home.path().into()), cx);
         });
         cx.run_until_parked();

--- a/vendor/gpui-omarchy/src/table.rs
+++ b/vendor/gpui-omarchy/src/table.rs
@@ -1,7 +1,9 @@
 //! Primitive tables: application-owned columns, rows and content.
 use crate::ActiveTheme;
-use gpui::{App, ElementId, FontWeight, InteractiveElement, Styled, prelude::FluentBuilder, px};
-use gpui_base::{Table, TableCell, TableHead, TableRow};
+use gpui_kit::base::{Table, TableCell, TableHead, TableRow};
+use gpui_kit::{
+    App, ElementId, FontWeight, InteractiveElement, Styled, prelude::FluentBuilder, px,
+};
 
 pub fn table(id: impl Into<ElementId>, cx: &App) -> Table {
     let t = cx.omarchy();

--- a/vendor/gpui-omarchy/src/text.rs
+++ b/vendor/gpui-omarchy/src/text.rs
@@ -1,19 +1,19 @@
 //! Read-only rich text using base's Markdown and HTML renderers.
 use crate::ActiveTheme;
-use gpui::{App, ElementId, SharedString, StyleRefinement, Styled, px, rems};
-use gpui_base::{TextView, TextViewStyle};
+use gpui_kit::base::{TextView, TextViewStyle};
+use gpui_kit::{App, ElementId, SharedString, StyleRefinement, Styled, px, rems};
 
 /// Theme mapping shared by Markdown, HTML and state-backed TextViews.
 pub fn text_view_style(cx: &App) -> TextViewStyle {
     let t = cx.omarchy();
-    TextViewStyle::from_theme(&gpui_base::Theme::global(cx))
+    TextViewStyle::from_theme(&gpui_kit::base::Theme::global(cx))
         .with_foreground(t.foreground)
         .with_muted_foreground(t.secondary)
         .with_link(t.accent)
         .with_selection(t.foreground.opacity(0.35))
         .with_border(t.divider())
         .with_code_background(t.normal_fill())
-        .with_inline_code(gpui::HighlightStyle {
+        .with_inline_code(gpui_kit::HighlightStyle {
             background_color: Some(t.normal_fill()),
             ..Default::default()
         })
@@ -49,7 +49,8 @@ pub fn html(id: impl Into<ElementId>, source: impl Into<SharedString>, cx: &App)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{Context, IntoElement, Render, TestAppContext, Window, div, point, prelude::*};
+    use gpui_kit::gpui;
+    use gpui_kit::{Context, IntoElement, Render, TestAppContext, Window, div, point, prelude::*};
 
     struct Document {
         html: bool,

--- a/vendor/gpui-omarchy/src/theme.rs
+++ b/vendor/gpui-omarchy/src/theme.rs
@@ -1,6 +1,6 @@
 //! Semantic palette and its projection into gpui-base.
-use gpui::{App, Global, Hsla, SharedString, px, rgb};
-use gpui_base::{ColorTokens, RadiusTokens, ThemeAppearance};
+use gpui_kit::base::{ColorTokens, RadiusTokens, ThemeAppearance};
+use gpui_kit::{App, Global, Hsla, SharedString, px, rgb};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Theme {
@@ -92,8 +92,8 @@ impl Theme {
     }
 
     /// Shell editors use foreground at 35%, independently of colors.toml selection.
-    pub fn input_style(&self) -> gpui_base::input::InputEditorStyle {
-        gpui_base::input::InputEditorStyle {
+    pub fn input_style(&self) -> gpui_kit::base::input::InputEditorStyle {
+        gpui_kit::base::input::InputEditorStyle {
             foreground: self.foreground,
             muted_foreground: self.foreground.opacity(0.55),
             background: self.normal_fill(),
@@ -135,7 +135,7 @@ impl Theme {
     }
 
     pub(crate) fn apply_palette(self, cx: &mut App) {
-        let base = gpui_base::Theme::global_mut(cx);
+        let base = gpui_kit::base::Theme::global_mut(cx);
         base.appearance = self.appearance;
         base.tokens.colors = self.tokens();
         base.tokens.radius = RadiusTokens {

--- a/vendor/gpui-omarchy/src/tooltip.rs
+++ b/vendor/gpui-omarchy/src/tooltip.rs
@@ -1,15 +1,15 @@
 //! Short, non-interactive explanations with GPUI's tooltip lifecycle.
 use crate::ActiveTheme;
-use gpui::{
+use gpui_kit::{
     App, AppContext, Context, Render, SharedString, StatefulInteractiveElement, Window, prelude::*,
     px,
 };
 use std::time::Duration;
 
 /// A composable tooltip surface, retaining the base tooltip role and styling API.
-pub fn tooltip(text: impl Into<SharedString>, cx: &App) -> gpui_base::Tooltip {
+pub fn tooltip(text: impl Into<SharedString>, cx: &App) -> gpui_kit::base::Tooltip {
     let t = cx.omarchy();
-    gpui_base::Tooltip::new("omarchy-tooltip")
+    gpui_kit::base::Tooltip::new("omarchy-tooltip")
         .max_w(px(320.))
         .px(px(10.))
         .py(px(6.))
@@ -36,7 +36,7 @@ pub fn with_tooltip<T: StatefulInteractiveElement>(control: T, text: impl Into<S
 struct TooltipText(SharedString);
 impl Render for TooltipText {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        gpui::div()
+        gpui_kit::div()
             .debug_selector(|| "omarchy-tooltip-surface".into())
             .child(tooltip(self.0.clone(), cx))
     }
@@ -45,11 +45,12 @@ impl Render for TooltipText {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{Render, TestAppContext, point};
+    use gpui_kit::gpui;
+    use gpui_kit::{Render, TestAppContext, point};
     struct Harness;
     impl Render for Harness {
         fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-            gpui::div().size_full().child(with_tooltip(
+            gpui_kit::div().size_full().child(with_tooltip(
                 crate::button("favorite", "Favorite", crate::ButtonVariant::Secondary, cx),
                 "Add to favorites",
             ))
@@ -62,7 +63,7 @@ mod tests {
         cx.update(|window, cx| {
             window.draw(cx).clear(cx);
         });
-        cx.simulate_event(gpui::MouseMoveEvent {
+        cx.simulate_event(gpui_kit::MouseMoveEvent {
             position: point(px(10.), px(10.)),
             pressed_button: None,
             modifiers: Default::default(),
@@ -82,7 +83,7 @@ mod tests {
             window.draw(cx).clear(cx);
         });
         assert!(cx.debug_bounds("omarchy-tooltip-surface").is_some());
-        cx.simulate_event(gpui::MouseMoveEvent {
+        cx.simulate_event(gpui_kit::MouseMoveEvent {
             position: point(px(400.), px(400.)),
             pressed_button: None,
             modifiers: Default::default(),

--- a/vendor/gpui-omarchy/src/tree.rs
+++ b/vendor/gpui-omarchy/src/tree.rs
@@ -1,6 +1,6 @@
 use crate::{ActiveTheme, IconName, icon};
-use gpui::{App, Entity, div, prelude::*, px};
-use gpui_base::{Tree, TreeState};
+use gpui_kit::base::{Tree, TreeState};
+use gpui_kit::{App, Entity, div, prelude::*, px};
 
 /// Virtualized, keyboard-navigable tree with application-owned base state.
 pub fn tree(state: &Entity<TreeState>, cx: &App) -> Tree {
@@ -50,8 +50,9 @@ pub fn tree(state: &Entity<TreeState>, cx: &App) -> Tree {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{Context, Render, TestAppContext, Window};
-    use gpui_base::TreeItem;
+    use gpui_kit::base::TreeItem;
+    use gpui_kit::gpui;
+    use gpui_kit::{Context, Render, TestAppContext, Window};
     struct Harness {
         state: Entity<TreeState>,
     }

--- a/vendor/gpui-omarchy/tests/interaction.rs
+++ b/vendor/gpui-omarchy/tests/interaction.rs
@@ -1,4 +1,5 @@
-use gpui::{
+use gpui_kit::gpui;
+use gpui_kit::{
     Context, IntoElement, Modifiers, Render, TestAppContext, Window, div, point, prelude::*, px,
 };
 use gpui_omarchy::*;
@@ -34,13 +35,13 @@ fn styled_button_accepts_pointer_return_and_space(cx: &mut TestAppContext) {
     assert_eq!(clicks.get(), 1);
     cx.update(|window, cx| window.draw(cx).clear(cx));
     for key in ["enter", "space"] {
-        let keystroke = gpui::Keystroke::parse(key).unwrap();
-        cx.simulate_event(gpui::KeyDownEvent {
+        let keystroke = gpui_kit::Keystroke::parse(key).unwrap();
+        cx.simulate_event(gpui_kit::KeyDownEvent {
             keystroke: keystroke.clone(),
             is_held: false,
             prefer_character_input: false,
         });
-        cx.simulate_event(gpui::KeyUpEvent { keystroke });
+        cx.simulate_event(gpui_kit::KeyUpEvent { keystroke });
     }
     assert_eq!(clicks.get(), 3);
 }
@@ -59,13 +60,13 @@ fn disabled_styled_button_cannot_activate(cx: &mut TestAppContext) {
     cx.update(|window, cx| window.focus_next(cx));
     cx.update(|window, cx| window.draw(cx).clear(cx));
     for key in ["enter", "space"] {
-        let keystroke = gpui::Keystroke::parse(key).unwrap();
-        cx.simulate_event(gpui::KeyDownEvent {
+        let keystroke = gpui_kit::Keystroke::parse(key).unwrap();
+        cx.simulate_event(gpui_kit::KeyDownEvent {
             keystroke: keystroke.clone(),
             is_held: false,
             prefer_character_input: false,
         });
-        cx.simulate_event(gpui::KeyUpEvent { keystroke });
+        cx.simulate_event(gpui_kit::KeyUpEvent { keystroke });
     }
     assert_eq!(clicks.get(), 0);
 }
@@ -75,9 +76,9 @@ fn applying_theme_updates_base_tokens_and_geometry(cx: &mut TestAppContext) {
     cx.update(|cx| {
         gpui_omarchy::init(cx);
         Theme::flexoki_light().apply(cx);
-        let base = gpui_base::Theme::global(cx);
+        let base = gpui_kit::base::Theme::global(cx);
         assert_eq!(base.tokens.colors, cx.omarchy().tokens());
-        assert_eq!(base.appearance, gpui_base::ThemeAppearance::Light);
+        assert_eq!(base.appearance, gpui_kit::base::ThemeAppearance::Light);
         for radius in [
             base.tokens.radius.none,
             base.tokens.radius.sm,
@@ -93,7 +94,7 @@ fn applying_theme_updates_base_tokens_and_geometry(cx: &mut TestAppContext) {
         for theme in [Theme::tokyo_night(), Theme::flexoki_light()] {
             let style = theme
                 .input_style()
-                .resolved(&gpui_base::SemanticThemeTokens {
+                .resolved(&gpui_kit::base::SemanticThemeTokens {
                     colors: theme.tokens(),
                     ..Default::default()
                 });
@@ -103,7 +104,7 @@ fn applying_theme_updates_base_tokens_and_geometry(cx: &mut TestAppContext) {
         }
         Theme::tokyo_night().apply(cx);
         assert_eq!(
-            gpui_base::Theme::global(cx).tokens.colors,
+            gpui_kit::base::Theme::global(cx).tokens.colors,
             cx.omarchy().tokens()
         );
     });


### PR DESCRIPTION
## Summary
Use only `gpui-kit` and `gpui-omarchy` as direct UI dependencies. Route base components and bundled assets through the kit facade, and retain `#[gpui::test]` via its GPUI re-export.

Update the vendored Omarchy fork to the 0.1.1 dependency convention while preserving the local menu, focus, and icon fixes. Keep UI dependencies optional so headless tests remain independent of GPUI.

Run routine CI on Linux only, including formatting, Clippy, installer, protocol, and UI tests, plus a parallel website build job using Bun 1.4.0 and the frozen lockfile. Trigger cross-platform release builds only for version tags or manual runs.

## Test Plan
- Root and vendored `cargo fmt` checks
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked --no-default-features`: 38 passed, 1 ignored
- `cargo test --locked --features ui-tests --bin omasend`: 16 passed
- `cargo build --locked`
- Vendored Omarchy `cargo check --all-targets`
- Dependency trees confirm only the two direct UI dependencies and no GPUI packages with default features disabled
- Actionlint validates both updated workflows; Linux runner execution remains to be verified by CI
- Website frozen dependency install and production build: passed (Astro check: 0 errors, 0 warnings)
