### PR TITLE
Simplify README around features and getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,146 +1,67 @@
 # Omasend
 
-A native GPUI + gpui-omarchy LocalSend client for Omarchy and Wayland.
+Copy, paste, and send to your other devices.
 
-Send files, folders, text, clipboard images and recordings to nearby LocalSend
-clients. Incoming transfers require acceptance and save to the XDG Downloads
-folder, with numbered names when a file already exists. History lasts for the
-current session. Exit stops networking. On macOS, closing the window keeps the
-session running; clicking the Dock icon restores it.
+Omasend is a desktop file-sharing app built for [Omarchy](https://omarchy.org).
+Send files, folders, screenshots, recordings, and text over your local network,
+with no account or cloud upload. Available for Linux, macOS, and Windows.
 
-The interface supports English and Simplified Chinese. It initially follows
-`LC_ALL`, `LC_MESSAGES`, then `LANG`; macOS falls back to its system locale.
-Choose English or 简体中文 in the menu to switch the current session. Device
-identity comes from the operating system, rather than the interface language.
+[Website](https://huacnlee.github.io/omasend/) · [Download](https://github.com/huacnlee/omasend/releases) · [Installation guide](docs/install.md)
 
-## Install and releases
+## Features
 
-See [installation instructions](docs/install.md) for macOS, Linux and Windows
-installers. Releases provide macOS Apple Silicon/Intel `.tar.gz` bundles,
-Linux x86_64/ARM64 `.tar.gz`, Windows x86_64 `.zip`, and SHA-256 checksums.
-The installers require a published GitHub release.
+- **Share with nearby devices.** Connect to Omasend and LocalSend clients on the same network.
+- **Paste or drop anything.** Add clipboard content, drag in files and folders, or use the file picker. Preview before sending.
+- **Keep transfers local.** Content travels directly between devices over an encrypted connection. You choose which incoming transfers to accept.
+- **Follow your transfers.** See progress and speed, cancel a transfer, and review the current session’s history. Received files go to Downloads without overwriting existing files.
+- **Make it feel at home.** Follow your Omarchy theme, choose System, Light, or Dark appearance, and switch between English and 简体中文.
+- **Stay up to date.** Check for updates from the menu, install them in the app, and restart when your transfers are finished.
 
-macOS / Linux:
+## Install
+
+Supports Linux x86_64 and ARM64, macOS Apple Silicon and Intel, and Windows x86_64.
+
+**macOS / Linux**
 
 ```sh
 curl -fsSL https://github.com/huacnlee/omasend/raw/refs/heads/main/install.sh | sh
 ```
 
-Windows PowerShell:
+**Windows PowerShell**
 
 ```powershell
 irm https://github.com/huacnlee/omasend/raw/refs/heads/main/install.ps1 | iex
 ```
 
-`.github/workflows/release.yml` builds and packages all platforms when run
-manually or for version tags; a tag matching `v<Cargo.toml version>` publishes the release after
-all builds pass. Modern macOS icon compilation requires Xcode 26 or newer.
+The installer selects the latest release for your device. For manual installation,
+custom locations, or removal, see the [installation guide](docs/install.md).
 
-The [website](website/README.md) uses Astro + Bun and GitHub Pages, following
-gpui-omarchy's setup. Its PR workflow builds and runs browser checks; deployment
-runs from `main` after Pages is configured to use GitHub Actions.
+## Send something
+
+1. Open Omasend or LocalSend on your other device and connect both devices to the same network.
+2. Paste content into Omasend, drag in files, or choose **Add files…**.
+3. Select a nearby device, click **Send**, and accept the transfer on the receiving device.
+
+Use `ctrl+v` to paste, `ctrl+o` to add files, and `enter` to send.
+On macOS, `cmd+v` and `cmd+o` also work. Closing the macOS window keeps
+Omasend available from the Dock; choose **Exit** to quit.
 
 ## Build and run
 
-Use a recent stable Rust toolchain with edition 2024 support. Development checks
-use Rust 1.98 on macOS and Rust 1.95 in the Linux verification container.
+Built with [GPUI Kit](https://gpui-kit.com/),
+[GPUI Omarchy](https://huacnlee.github.io/gpui-omarchy/), and the
+[LocalSend Rust core](https://github.com/localsend/localsend).
 
-Linux needs a C/C++ compiler, CMake, pkg-config, Fontconfig/FreeType, xkbcommon
-(including X11 support), Wayland and Vulkan development libraries. Runtime
-requires a working graphics driver, `wl-clipboard` for paste, and a desktop
-portal/file manager for native file selection and opening received files.
+With a recent stable Rust toolchain and your platform’s development libraries:
 
 ```sh
-cargo build --release --locked
-./target/release/omasend
+cargo run --release --locked
 ```
 
-Only one LocalSend server can normally use TCP port 53317 on the same machine.
-Discovery uses UDP 53317 multicast and periodically probes local private IPv4
-subnets through the official core. Small LANs through /22 are covered fully;
-for larger networks the fallback is bounded to the interface's own /24.
-HTTPS and certificate fingerprint verification remain enabled.
+Linux builds require a C/C++ compiler, CMake, pkg-config, and development libraries
+for OpenSSL, Fontconfig, FreeType, xkbcommon, X11/XCB, Wayland, Vulkan, and Zstandard.
+Install `wl-clipboard` for clipboard support on Wayland.
 
-Install for the current Linux user after building:
+## License
 
-```sh
-install -Dm755 target/release/omasend "$HOME/.local/bin/omasend"
-install -Dm644 packaging/omasend.desktop "$HOME/.local/share/applications/omasend.desktop"
-install -Dm644 assets/omasend.png "$HOME/.local/share/icons/hicolor/1024x1024/apps/omasend.png"
-```
-
-Ensure `~/.local/bin` is on PATH. On Omarchy, use
-`omarchy-launch-or-focus omasend` to launch or focus the window.
-
-## Controls
-
-- `ctrl+v`: paste files, images, video or text.
-- `ctrl+o`: choose files or folders.
-- Arrow keys: choose a nearby device.
-- `enter`: send / confirm; `esc`: cancel / go back.
-- `tab` / `shift+tab`: move keyboard focus.
-- Logs… in the menu opens the latest 500 session log events, with copy and
-  clear actions. Ordinary background discovery timeouts stay in the logs.
-- Exit is in the menu. Omarchy's compositor owns `super+w` window closing;
-  Omasend does not override it or bind `ctrl+q`.
-- macOS also accepts `cmd+v`, `cmd+o`, and `cmd+q`. `cmd+w` closes the
-  window while keeping the session available from the Dock.
-
-Folders expand to relative file paths; empty directories are not transferred.
-Clipboard file URIs use the original file. Clipboard media is streamed to a
-private temporary file under `$XDG_RUNTIME_DIR/omasend` and removed after its
-last composer/transfer owner releases it. Text and file references are not
-materialized into media copies.
-
-## Verification
-
-```sh
-cargo fmt --all -- --check
-cargo check --all-targets --locked
-cargo clippy --all-targets --locked -- -D warnings
-cargo test --no-default-features --locked
-cargo test --features ui-tests --bin omasend --locked
-```
-
-The default feature is the desktop app. Disabling it exposes no separate CLI;
-it allows filesystem, clipboard-process, state and real HTTPS integration
-tests to run without a display. The ignored `native_window` fixture requires
-an open application and manual interaction; it does not run in the default
-suite.
-
-All-target desktop compilation and 22 headless tests pass on macOS and in a
-Linux Debian container. macOS native UI and bidirectional transfers with a
-LocalSend desktop peer have been exercised. Real iPhone discovery/interoperability and a real Linux
-Wayland desktop session remain unverified. Receiver PIN entry is not yet
-exposed in the interface. Language selection and history are session-only.
-
-## Dependencies and assets
-
-`vendor/localsend` pins the official Rust core to the commit recorded in its
-`UPSTREAM.md`, with a local discovery-diagnostic event patch; TLS verification
-is unchanged. WebRTC and web sharing are disabled.
-`vendor/gpui-omarchy` pins version 0.1.0 with menu shortcuts rendered by its
-existing `keycap` component and keyboard traversal respecting modal focus traps.
-See its `UPSTREAM.txt`.
-
-The original Omasend emblem is inspired by LocalSend's local-discovery shape
-and Omarchy's pixel geometry; it is not either project's official mark. Linux
-uses the square PNG; macOS combines Icon Composer assets for modern systems
-with a rounded, transparent-margin ICNS for older releases.
-The header logo is static; the empty send area animates its outer pixel segments.
-Both render a transparent vector emblem in the current theme's accent color.
-GPUI's reduced-motion setting renders a static logo.
-
-The menu includes About… with the current version and Check for update.
-Omasend checks GitHub's latest stable release at startup and every six hours.
-Click Install in the status bar to download and install that version with
-[self_update](https://github.com/jaemk/self_update). The updater requires the
-release's SHA256SUMS checksum before replacing files. macOS updates the entire
-signed OmaSend.app bundle; Linux and Windows replace the executable in place.
-The installation directory must be writable by the current user.
-
-Download progress, installation status, retry, and Restart to update appear in
-the status bar. Restart is available after transfers finish and Outbox is empty;
-network services shut down before the new process starts. Update failures leave
-details in Logs. On macOS, run the installed .app to update, rather than a bare
-development binary. Routine check results disappear after five seconds.
+MIT licensed. An independent community project.


### PR DESCRIPTION
## Summary
Rewrite the README around sharing features, installation, and a three-step sending workflow. Retain concise build instructions and project credits, and remove protocol internals, CI details, and historical verification notes from the introduction.

## Test Plan
- Verified relative links and code fences
- git diff --check passed
- Documentation only; no application code changed
