### PR TITLE
feat: add Omarchy package support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
           key: ci-tests
       - name: Unix installer tests
         run: python scripts/test-install.py
+      - name: Arch package recipe tests
+        run: python scripts/test-pkgbuild.py
       - name: Unit and integration tests
         run: cargo test --locked --no-default-features
       - name: GPUI interaction tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "omasend"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omasend"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "MIT"
 description = "An Omarchy native LocalSend client"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jason Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Jason Lee <huacnlee@gmail.com>
+pkgname=omasend
+pkgver=0.1.3
+pkgrel=1
+pkgdesc='Omarchy-native LocalSend client'
+arch=('x86_64' 'aarch64')
+url='https://github.com/huacnlee/omasend'
+license=('MIT')
+depends=(
+  'fontconfig'
+  'freetype2'
+  'gcc-libs'
+  'glibc'
+  'hicolor-icon-theme'
+  'libxkbcommon'
+  'libxcb'
+  'omarchy'
+  'openssl'
+  'vulkan-icd-loader'
+  'wayland'
+  'zstd'
+)
+makedepends=('cargo' 'clang' 'cmake' 'pkgconf')
+optdepends=('wl-clipboard: paste clipboard content on Wayland')
+options=('!debug')
+
+# This recipe is built from a repository checkout, as used by Omarchy's local
+# package workflow and by `makepkg` run from a clone.
+source=()
+
+build() {
+  export CARGO_TARGET_DIR="$srcdir/target"
+  cd "$startdir"
+  cargo build --release --locked
+}
+
+check() {
+  export CARGO_TARGET_DIR="$srcdir/target"
+  cd "$startdir"
+  cargo test --locked --no-default-features
+}
+
+package() {
+  cd "$startdir"
+  install -Dm755 "$srcdir/target/release/omasend" "$pkgdir/usr/bin/omasend"
+  install -Dm644 packaging/omasend.desktop \
+    "$pkgdir/usr/share/applications/omasend.desktop"
+  install -Dm644 assets/omasend.png \
+    "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/omasend.png"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Keep both devices on the same network, and allow TCP and UDP port `53317` throug
 
 Supports Linux x86_64 and ARM64, macOS Apple Silicon and Intel, and Windows x86_64.
 
+**Omarchy**
+
+```sh
+omarchy pkg add omasend
+```
+
 **macOS / Linux**
 
 ```sh

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,6 +7,17 @@ access. A release must have been published before these commands can succeed.
 Published builds support Apple Silicon and Intel macOS, x86_64 and ARM64 Linux, and
 x86_64 Windows. Other architectures require a source build.
 
+## Omarchy
+
+Install Omasend from the Omarchy package repository:
+
+```sh
+omarchy pkg add omasend
+```
+
+Omasend will then be updated with the rest of the system by `omarchy update`.
+Remove it with `omarchy pkg drop omasend`.
+
 ## macOS and Linux
 
 ```sh

--- a/scripts/test-pkgbuild.py
+++ b/scripts/test-pkgbuild.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Exercise the Arch package recipe without invoking makepkg or compiling Rust."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+PKGBUILD = ROOT / "PKGBUILD"
+
+
+class PkgbuildTests(unittest.TestCase):
+    def test_builds_and_installs_desktop_application(self):
+        with tempfile.TemporaryDirectory(prefix="omasend-pkgbuild-test-") as temporary:
+            work = Path(temporary)
+            fake_bin = work / "bin"
+            fake_bin.mkdir()
+            install = shutil.which("ginstall") or shutil.which("install")
+            self.assertIsNotNone(install)
+            (fake_bin / "install").symlink_to(install)
+            cargo_log = work / "cargo.log"
+            cargo = fake_bin / "cargo"
+            cargo.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n' \"$*\" > \"$CARGO_LOG\"\n"
+                "mkdir -p \"$CARGO_TARGET_DIR/release\"\n"
+                "printf '#!/bin/sh\\n' > \"$CARGO_TARGET_DIR/release/omasend\"\n"
+                "chmod 755 \"$CARGO_TARGET_DIR/release/omasend\"\n"
+            )
+            cargo.chmod(0o755)
+
+            pkgdir = work / "pkg"
+            srcdir = work / "src"
+            pkgdir.mkdir()
+            srcdir.mkdir()
+            command = (
+                'set -eu; source "$RECIPE"; '
+                '[ "$pkgname" = omasend ]; '
+                '[[ " ${arch[*]} " == *" x86_64 "* ]]; '
+                '[[ " ${arch[*]} " == *" aarch64 "* ]]; '
+                "build; package"
+            )
+            env = dict(
+                os.environ,
+                PATH=f"{fake_bin}:{os.environ['PATH']}",
+                CARGO_LOG=str(cargo_log),
+                RECIPE=str(PKGBUILD),
+                startdir=str(ROOT),
+                srcdir=str(srcdir),
+                pkgdir=str(pkgdir),
+            )
+            result = subprocess.run(
+                ["bash", "-c", command], env=env, capture_output=True, text=True
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(cargo_log.read_text().strip(), "build --release --locked")
+            self.assertTrue(os.access(pkgdir / "usr/bin/omasend", os.X_OK))
+            self.assertTrue((pkgdir / "usr/share/applications/omasend.desktop").is_file())
+            self.assertTrue(
+                (pkgdir / "usr/share/icons/hicolor/1024x1024/apps/omasend.png").is_file()
+            )
+            license_file = pkgdir / "usr/share/licenses/omasend/LICENSE"
+            self.assertIn("MIT License", license_file.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an Arch PKGBUILD for x86_64 and aarch64 Omarchy systems
- install the desktop entry, icon, and MIT license
- test the package recipe in CI and document Omarchy installation

## Test Plan

- `python scripts/test-pkgbuild.py`
- `python scripts/test-install.py`
- `cargo test --locked --no-default-features`
- `cargo fmt --all -- --check`
- `bash -n PKGBUILD`
- `git diff --check`